### PR TITLE
feat(DialogReportInsight): Add time_period.vulnerability_count object null check

### DIFF
--- a/src/components/Dialog/DialogReportInsight.vue
+++ b/src/components/Dialog/DialogReportInsight.vue
@@ -175,7 +175,7 @@
       name: 'Count',
       type: 'line',
       data: insightInformation.value.vulnerability_trends.time_periods.map(
-        period => period.vulnerability_count.toFixed(2)
+        period => period.vulnerability_count == null ? null : period.vulnerability_count.toFixed(2)
       )
     },
     {


### PR DESCRIPTION
A bug was going on where averages were mis-represented, e.g: For 12 months but just 1 scan on February, all other months would show 0 vulnerabilities, which led the average to be much lower than 12, and the user to believe no vulnerabilities were being found.

On the backend,[a change was made to differentiate 0 from null,](https://github.com/kptm-tools/core-service/pull/94) as in 0 vulnerabilities from "no data". The DTO now reflects this.