### PR TITLE
Feature/kt 397 add verifyemailpage

### DIFF
--- a/src/components/Dialog/DialogReportInsight.vue
+++ b/src/components/Dialog/DialogReportInsight.vue
@@ -175,7 +175,10 @@
       name: 'Count',
       type: 'line',
       data: insightInformation.value.vulnerability_trends.time_periods.map(
-        period => period.vulnerability_count == null ? null : period.vulnerability_count.toFixed(2)
+        period =>
+          period.vulnerability_count == null
+            ? null
+            : period.vulnerability_count.toFixed(2)
       )
     },
     {

--- a/src/pages/auth/VerifyEmailPage.vue
+++ b/src/pages/auth/VerifyEmailPage.vue
@@ -1,52 +1,52 @@
 <template>
   <div>
     <p v-if="loading">Verifying your email...</p>
-    <p v-else-if="errorMessage" style="color: red;">{{errorMessage}}</p>
+    <p v-else-if="errorMessage" style="color: red">{{ errorMessage }}</p>
   </div>
 </template>
 
 <script lang="ts" setup>
-import { onMounted, ref } from 'vue';
-import { AxiosError } from 'axios';
-import { useRouter, useRoute } from 'vue-router';
-import { UserService } from 'src/services/user.service';
-import { errorQuasarNotify, successQuasarNotify } from 'src/utils';
+  import { onMounted, ref } from 'vue';
+  import { AxiosError } from 'axios';
+  import { useRouter, useRoute } from 'vue-router';
+  import { UserService } from 'src/services/user.service';
+  import { errorQuasarNotify, successQuasarNotify } from 'src/utils';
 
-const router = useRouter();
-const route = useRoute();
-const loading = ref(false);
-const errorMessage = ref<string | null>(null);
+  const router = useRouter();
+  const route = useRoute();
+  const loading = ref(false);
+  const errorMessage = ref<string | null>(null);
 
-onMounted(async () => {
-  loading.value = true;
-  const verificationId = route.query.verificationId as string | undefined;
-  const tenantId = route.query.tenantId as string | undefined;
+  onMounted(async () => {
+    loading.value = true;
+    const verificationId = route.query.verificationId as string | undefined;
+    const tenantId = route.query.tenantId as string | undefined;
 
-  if (!verificationId || !tenantId) {
-    errorMessage.value = 'Invalid verification link. Missing parameters.'
-    loading.value = false;
-    return
-  }
-
-  try {
-    await UserService.verifyEmail(verificationId, tenantId);
-
-    successQuasarNotify('Email was verified successfully.')
-    await new Promise(resolve => setTimeout(resolve, 1000));
-    loading.value = false;
-    router.push({ name: 'Login' });
-  } catch (error) {
-    const axiosError = error as AxiosError;
-    const errorData = axiosError.response?.data as {error?: string } | undefined;
-    if (errorData?.error) {
-      errorMessage.value = errorData.error;
-      errorQuasarNotify(errorData.error);
-    } else {
-      errorQuasarNotify('An unexpected error occurred.');
-      console.error('Error details:', error);
+    if (!verificationId || !tenantId) {
+      errorMessage.value = 'Invalid verification link. Missing parameters.';
+      loading.value = false;
+      return;
     }
 
-  }
-})
+    try {
+      await UserService.verifyEmail(verificationId, tenantId);
 
+      successQuasarNotify('Email was verified successfully.');
+      await new Promise(resolve => setTimeout(resolve, 1000));
+      loading.value = false;
+      router.push({ name: 'Login' });
+    } catch (error) {
+      const axiosError = error as AxiosError;
+      const errorData = axiosError.response?.data as
+        | { error?: string }
+        | undefined;
+      if (errorData?.error) {
+        errorMessage.value = errorData.error;
+        errorQuasarNotify(errorData.error);
+      } else {
+        errorQuasarNotify('An unexpected error occurred.');
+        console.error('Error details:', error);
+      }
+    }
+  });
 </script>

--- a/src/pages/auth/VerifyEmailPage.vue
+++ b/src/pages/auth/VerifyEmailPage.vue
@@ -1,0 +1,52 @@
+<template>
+  <div>
+    <p v-if="loading">Verifying your email...</p>
+    <p v-else-if="errorMessage" style="color: red;">{{errorMessage}}</p>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { onMounted, ref } from 'vue';
+import { AxiosError } from 'axios';
+import { useRouter, useRoute } from 'vue-router';
+import { UserService } from 'src/services/user.service';
+import { errorQuasarNotify, successQuasarNotify } from 'src/utils';
+
+const router = useRouter();
+const route = useRoute();
+const loading = ref(false);
+const errorMessage = ref<string | null>(null);
+
+onMounted(async () => {
+  loading.value = true;
+  const verificationId = route.query.verificationId as string | undefined;
+  const tenantId = route.query.tenantId as string | undefined;
+
+  if (!verificationId || !tenantId) {
+    errorMessage.value = 'Invalid verification link. Missing parameters.'
+    loading.value = false;
+    return
+  }
+
+  try {
+    await UserService.verifyEmail(verificationId, tenantId);
+
+    successQuasarNotify('Email was verified successfully.')
+    await new Promise(resolve => setTimeout(resolve, 1000));
+    loading.value = false;
+    router.push({ name: 'Login' });
+  } catch (error) {
+    const axiosError = error as AxiosError;
+    const errorData = axiosError.response?.data as {error?: string } | undefined;
+    if (errorData?.error) {
+      errorMessage.value = errorData.error;
+      errorQuasarNotify(errorData.error);
+    } else {
+      errorQuasarNotify('An unexpected error occurred.');
+      console.error('Error details:', error);
+    }
+
+  }
+})
+
+</script>

--- a/src/router/routes-names.ts
+++ b/src/router/routes-names.ts
@@ -4,6 +4,7 @@ export const ROUTES_NAMES = {
   registerUser: 'RegisterUser',
   recoverPassword: 'RecoverPassword',
   resetPassword: 'ResetPassword',
+  verifyEmail: 'VerifyEmail',
   hosts: 'Hosts',
   scans: 'Scans',
   reports: 'Reports',

--- a/src/router/routes.ts
+++ b/src/router/routes.ts
@@ -104,7 +104,6 @@ const routes: RouteRecordRaw[] = [
         },
         component: () => import('pages/auth/VerifyEmailPage.vue')
       }
-
     ]
   },
 

--- a/src/router/routes.ts
+++ b/src/router/routes.ts
@@ -95,7 +95,16 @@ const routes: RouteRecordRaw[] = [
           title: 'Reset Password'
         },
         component: () => import('pages/auth/ResetPasswordPage.vue')
+      },
+      {
+        path: 'verify',
+        name: ROUTES_NAMES.verifyEmail,
+        meta: {
+          title: 'Verify Email'
+        },
+        component: () => import('pages/auth/VerifyEmailPage.vue')
       }
+
     ]
   },
 

--- a/src/services/user.service.ts
+++ b/src/services/user.service.ts
@@ -1,7 +1,7 @@
 import { AxiosResponse } from 'axios';
 import {
   CreateUserBody,
-  SuccessAuthLoginUser,
+  SuccessAuthLoginUser
 } from 'src/models/fusion-auth.models';
 import { fusionAuthApi } from 'boot/axios';
 
@@ -25,7 +25,7 @@ export class UserService {
     tenantId: string
   ): Promise<AxiosResponse> {
     return fusionAuthApi.get(
-      `${this.BASE_PATH}/verify?verificationId=${verificationId}&tenantId=${tenantId}`,
+      `${this.BASE_PATH}/verify?verificationId=${verificationId}&tenantId=${tenantId}`
     );
   }
 }

--- a/src/services/user.service.ts
+++ b/src/services/user.service.ts
@@ -25,7 +25,7 @@ export class UserService {
     tenantId: string
   ): Promise<AxiosResponse> {
     return fusionAuthApi.get(
-      `${this.BASE_PATH}/verify?verificationId=${verificationId}&tenandId=${tenantId}`,
+      `${this.BASE_PATH}/verify?verificationId=${verificationId}&tenantId=${tenantId}`,
     );
   }
 }

--- a/src/services/user.service.ts
+++ b/src/services/user.service.ts
@@ -2,7 +2,6 @@ import { AxiosResponse } from 'axios';
 import {
   CreateUserBody,
   SuccessAuthLoginUser,
-  VerifyEmailBody
 } from 'src/models/fusion-auth.models';
 import { fusionAuthApi } from 'boot/axios';
 
@@ -22,16 +21,11 @@ export class UserService {
   }
 
   static async verifyEmail(
-    userId: string,
-    tenantId: string,
-    body: VerifyEmailBody
+    verificationId: string,
+    tenantId: string
   ): Promise<AxiosResponse> {
-    return fusionAuthApi.post(
-      `${this.BASE_PATH}/${userId}/verify-email`,
-      body,
-      {
-        headers: { 'X-TenantId': tenantId }
-      }
+    return fusionAuthApi.get(
+      `${this.BASE_PATH}/verify?verificationId=${verificationId}&tenandId=${tenantId}`,
     );
   }
 }

--- a/src/utils/notify.utils.ts
+++ b/src/utils/notify.utils.ts
@@ -18,7 +18,7 @@ export function successQuasarNotify(
   message: string,
   icon = 'check_circle',
   position: QNotifyPosition = 'top-right'
-) : void {
+): void {
   Notify.create({
     message,
     color: 'positive',

--- a/src/utils/notify.utils.ts
+++ b/src/utils/notify.utils.ts
@@ -13,3 +13,16 @@ export function errorQuasarNotify(
     position
   });
 }
+
+export function successQuasarNotify(
+  message: string,
+  icon = 'check_circle',
+  position: QNotifyPosition = 'top-right'
+) : void {
+  Notify.create({
+    message,
+    color: 'positive',
+    icon,
+    position
+  });
+}


### PR DESCRIPTION
## PR Description

This PR adds a new `VerifyEmailPage`, which is the page to which the user will be redirected when he clicks on his verification email URL. 

- The page hits the backend endpoint for email verification
- The route handles query parameters gracefully
- A couple of helper functions were added for notifications
- On success, the user is redirected to the Login Page. On failure, an error message is displayed.


This effectively avoids having to expose FusionAuth and the Core-Service API publicly. 