### PR TITLE
Feature/kt 372 comment functionality

### DIFF
--- a/src/components/report/VulnerabilityCard.vue
+++ b/src/components/report/VulnerabilityCard.vue
@@ -39,17 +39,35 @@
             <div class="text-title">Description</div>
             <div class="text-muted">{{ vul.description }}</div>
           </q-card-section>
-          <q-card-section v-if="vul.comment">
+          <q-card-section v-if="vul.comment != null">
             <div class="text-title">Comment</div>
-            <div class="text-muted">{{ vul.comment }}</div>
-            <div class="row justify-end">
-              <q-btn color="red-8" label="Delete" :loading="deletingComment" class="qt-mt-md"
-                @click="deleteAnalystComment(vul.id.toString())">
-                <template #loading>
-                  <q-spinner-bars />
-                </template>
-              </q-btn>
-            </div>
+            <template v-if="editModeEnabled">
+              <div class="text-muted">
+                <q-input v-model="editedAnalystCommentText" hint="Type a comment" filled></q-input>
+                <div class="row justify-end">
+                  <q-btn label="Cancel" color="grey-9" @click="editModeEnabled = false" />
+                  <q-btn tnumberype="submit" :loading="submittingComment" color="primary" label="Submit"
+                    class="qt-mt-md" @click="patchAnalystComment(vul.id.toString())">
+                    <template #loading>
+                      <q-spinner-bars />
+                    </template>
+                  </q-btn>
+                </div>
+              </div>
+            </template>
+            <template v-else>
+              <div class="text-muted">{{ vul.comment }}</div>
+              <div class="row justify-end">
+                <q-btn color="warning" label="Edit" class="qt-mt-md" @click="enableEditAnalystComment(vul.comment)" />
+                <q-btn color="red-8" label="Delete" :loading="deletingComment" class="qt-mt-md"
+                  @click="deleteAnalystComment(vul.id.toString())">
+                  <template #loading>
+                    <q-spinner-bars />
+                  </template>
+                </q-btn>
+              </div>
+
+            </template>
           </q-card-section>
           <q-card-section v-else>
             <div class="text-title">Write an Analyst Comment</div>
@@ -137,6 +155,8 @@ const showInfo = ref(false);
 const analystCommentText = ref('')
 const submittingComment = ref(false);
 const deletingComment = ref(false);
+const editModeEnabled = ref(false);
+const editedAnalystCommentText = ref('');
 
 const cardColor = (cvss: number) => {
   let color = '';
@@ -195,6 +215,36 @@ async function deleteAnalystComment(vulnID: string) {
       console.error('Error details:', error);
     }
     deletingComment.value = false
+  }
+}
+
+function enableEditAnalystComment(vulnComment: string | undefined): void {
+  editModeEnabled.value = true;
+  editedAnalystCommentText.value = vulnComment || '';
+}
+
+async function patchAnalystComment(vulnID: string) {
+  submittingComment.value = true
+
+  try {
+    await VulnerabilitesService.patchVulnerabilityComment(vulnID, editedAnalystCommentText.value)
+    successQuasarNotify('Analyst Comment was edited successfully.');
+    submittingComment.value = false;
+    editModeEnabled.value = false;
+  } catch (error) {
+    const axiosError = error as AxiosError;
+    const errorData = axiosError.response?.data as
+      | { error?: string }
+      | undefined;
+
+    if (errorData?.error) {
+      errorQuasarNotify(errorData.error);
+    } else {
+      errorQuasarNotify('An unexpected error occurred.');
+      console.error('Error details:', error);
+    }
+    submittingComment.value = false
+    editModeEnabled.value = false;
   }
 }
 

--- a/src/components/report/VulnerabilityCard.vue
+++ b/src/components/report/VulnerabilityCard.vue
@@ -43,6 +43,21 @@
             <div class="text-title">Comment</div>
             <div class="text-muted">{{ vul.comment }}</div>
           </q-card-section>
+          <q-card-section v-else>
+            <div class="text-title">Write an Analyst Comment</div>
+            <div class="text-muted">
+              <q-input v-model="analystCommentText" hint="Type a comment" filled></q-input>
+              <div class="row justify-end">
+                <q-btn tnumberype="submit" :loading="submittingComment" color="primary" label="Add comment"
+                  class="qt-mt-md" @click="submitAnalystComment(vul.id.toString())">
+                  <template #loading>
+                    <q-spinner-bars />
+                  </template>
+                </q-btn>
+
+              </div>
+            </div>
+          </q-card-section>
           <q-card-section v-if="vul.recommendation">
             <div class="text-title">Recommendation</div>
             <div class="text-muted">{{ vul.recommendation }}</div>
@@ -78,18 +93,12 @@
             </div>
           </q-card-section>
           <q-card-section v-if="detailView" align="right">
-            <q-btn
-              color="primary"
-              label="Report"
-              no-caps
-              size="md"
-              @click="
-                $router.push({
-                  name: ROUTES_NAMES.reportsDetailVul,
-                  params: { idvul: vul.id }
-                })
-              "
-            ></q-btn>
+            <q-btn color="primary" label="Report" no-caps size="md" @click="
+              $router.push({
+                name: ROUTES_NAMES.reportsDetailVul,
+                params: { idvul: vul.id }
+              })
+              "></q-btn>
           </q-card-section>
         </div>
       </q-card>
@@ -98,124 +107,160 @@
 </template>
 
 <script setup lang="ts">
-  import { ScanVulnerability } from 'src/models';
-  import { ROUTES_NAMES } from 'src/router/routes-names';
-  import { onMounted, ref } from 'vue';
+import { AxiosError } from 'axios';
+import { ScanVulnerability } from 'src/models';
+import { ROUTES_NAMES } from 'src/router/routes-names';
+import { VulnerabilitesService } from 'src/services';
+import { errorQuasarNotify, successQuasarNotify } from 'src/utils';
+import { onMounted, ref } from 'vue';
 
-  const props = defineProps({
-    vul: {
-      type: {} as () => ScanVulnerability,
-      required: true
-    },
-    detailView: {
-      type: Boolean,
-      default: () => true
-    }
-  });
-
-  const showInfo = ref(false);
-
-  const cardColor = (cvss: number) => {
-    let color = '';
-    if (cvss > 0 && cvss < 3.9) color = 'green';
-    else if (cvss > 3.9 && cvss < 6.9) color = 'yellow';
-    else if (cvss > 6.9 && cvss < 9) color = 'orange';
-    else if (cvss >= 9) color = 'red';
-    return color;
-  };
-
-  function showInfoHandler(): void {
-    showInfo.value = !showInfo.value;
+const props = defineProps({
+  vul: {
+    type: {} as () => ScanVulnerability,
+    required: true
+  },
+  detailView: {
+    type: Boolean,
+    default: () => true
   }
+});
 
-  onMounted(() => {
-    if (!props.detailView) {
-      showInfo.value = true;
+const showInfo = ref(false);
+const analystCommentText = ref('')
+const submittingComment = ref(false);
+
+const cardColor = (cvss: number) => {
+  let color = '';
+  if (cvss > 0 && cvss < 3.9) color = 'green';
+  else if (cvss > 3.9 && cvss < 6.9) color = 'yellow';
+  else if (cvss > 6.9 && cvss < 9) color = 'orange';
+  else if (cvss >= 9) color = 'red';
+  return color;
+};
+
+function showInfoHandler(): void {
+  showInfo.value = !showInfo.value;
+}
+
+async function submitAnalystComment(vulnID: string) {
+  submittingComment.value = true
+
+  try {
+    await VulnerabilitesService.postVulnerabilityComment(vulnID, analystCommentText.value)
+    successQuasarNotify('Analyst Comment was submitted successfully.');
+    submittingComment.value = false
+  } catch (error) {
+    const axiosError = error as AxiosError;
+    const errorData = axiosError.response?.data as
+      | { error?: string }
+      | undefined;
+
+    if (errorData?.error) {
+      errorQuasarNotify(errorData.error);
+    } else {
+      errorQuasarNotify('An unexpected error occurred.');
+      console.error('Error details:', error);
     }
-  });
+    submittingComment.value = false
+
+  }
+}
+
+onMounted(() => {
+  if (!props.detailView) {
+    showInfo.value = true;
+  }
+});
 </script>
 
 <style lang="scss" scoped>
-  .card {
-    &-vul {
-      background-color: #f6f7fc;
-      overflow-y: auto;
-    }
-    &-yellow {
-      border-left: #fbbf65 10px solid;
-    }
-    &-red {
-      border-left: #e5494d 10px solid;
-    }
-    &-green {
-      border-left: #97b951 10px solid;
-    }
-    &-orange {
-      border-left: #f3a488 10px solid;
+.card {
+  &-vul {
+    background-color: #f6f7fc;
+    overflow-y: auto;
+  }
+
+  &-yellow {
+    border-left: #fbbf65 10px solid;
+  }
+
+  &-red {
+    border-left: #e5494d 10px solid;
+  }
+
+  &-green {
+    border-left: #97b951 10px solid;
+  }
+
+  &-orange {
+    border-left: #f3a488 10px solid;
+  }
+}
+
+.cvss {
+  &-yellow {
+    .value {
+      border: #fbbf65 1px solid;
+      background: #fbbf651a;
+      padding: 0 5px;
+      width: fit-content;
+      font-weight: 500;
+      color: black;
     }
   }
 
-  .cvss {
-    &-yellow {
-      .value {
-        border: #fbbf65 1px solid;
-        background: #fbbf651a;
-        padding: 0 5px;
-        width: fit-content;
-        font-weight: 500;
-        color: black;
-      }
-    }
-    &-red {
-      .value {
-        border: #e5494d 1px solid;
-        background: #ed273d1a;
-        padding: 0 5px;
-        width: fit-content;
-        font-weight: 500;
-        color: black;
-      }
-    }
-    &-green {
-      .value {
-        border: #97b951 1px solid;
-        background: #46a7581a;
-        padding: 0 5px;
-        width: fit-content;
-        font-weight: 500;
-        color: black;
-      }
-    }
-    &-orange {
-      .value {
-        border: #f3a488 1px solid;
-        background: #fbbf651a;
-        padding: 0 5px;
-        width: fit-content;
-        font-weight: 500;
-        color: black;
-      }
+  &-red {
+    .value {
+      border: #e5494d 1px solid;
+      background: #ed273d1a;
+      padding: 0 5px;
+      width: fit-content;
+      font-weight: 500;
+      color: black;
     }
   }
 
-  .text-title {
-    color: #313541;
-    font-weight: 700;
-    font-size: 16px;
+  &-green {
+    .value {
+      border: #97b951 1px solid;
+      background: #46a7581a;
+      padding: 0 5px;
+      width: fit-content;
+      font-weight: 500;
+      color: black;
+    }
   }
 
-  .text-muted {
-    color: #5c7288;
-    font-size: 11px;
+  &-orange {
+    .value {
+      border: #f3a488 1px solid;
+      background: #fbbf651a;
+      padding: 0 5px;
+      width: fit-content;
+      font-weight: 500;
+      color: black;
+    }
   }
+}
 
-  .v-enter-active,
-  .v-leave-active {
-    transition: opacity 0.5s ease;
-  }
+.text-title {
+  color: #313541;
+  font-weight: 700;
+  font-size: 16px;
+}
 
-  .v-enter-from,
-  .v-leave-to {
-    opacity: 0;
-  }
+.text-muted {
+  color: #5c7288;
+  font-size: 11px;
+}
+
+.v-enter-active,
+.v-leave-active {
+  transition: opacity 0.5s ease;
+}
+
+.v-enter-from,
+.v-leave-to {
+  opacity: 0;
+}
 </style>

--- a/src/components/report/VulnerabilityCard.vue
+++ b/src/components/report/VulnerabilityCard.vue
@@ -254,8 +254,12 @@
         analystCommentText.value
       );
       successQuasarNotify('Analyst Comment was submitted successfully.');
+      emit('comment-updated', {
+        vulID: parseInt(vulnID),
+        newComment: analystCommentText.value
+      });
       submittingComment.value = false;
-      emit('comment-updated', analystCommentText.value);
+      analystCommentText.value = '';
     } catch (error) {
       const axiosError = error as AxiosError;
       const errorData = axiosError.response?.data as
@@ -279,7 +283,10 @@
       await VulnerabilitesService.deleteVulnerabilityComment(vulnID);
       successQuasarNotify('Analyst Comment was deleted successfully.');
       deletingComment.value = false;
-      emit('comment-updated', null);
+      emit('comment-updated', {
+        vulID: parseInt(vulnID),
+        newComment: ''
+      });
     } catch (error) {
       const axiosError = error as AxiosError;
       const errorData = axiosError.response?.data as

--- a/src/components/report/VulnerabilityCard.vue
+++ b/src/components/report/VulnerabilityCard.vue
@@ -44,12 +44,25 @@
             <div class="text-title">Comment</div>
             <template v-if="isEditingComment">
               <div class="text-muted">
-                <q-input v-model="editedAnalystCommentText" hint="Type a comment" filled></q-input>
+                <q-input
+                  v-model="editedAnalystCommentText"
+                  hint="Type a comment"
+                  filled
+                ></q-input>
                 <div class="row justify-end">
-                  <q-btn label="Cancel" color="grey-9" class="q-mr-sm" @click="editModeEnabled = false" />
                   <q-btn
-tnumberype="submit" :loading="submittingComment" color="primary" label="Save"
-                    @click="patchAnalystComment(vul.id.toString())">
+                    label="Cancel"
+                    color="grey-9"
+                    class="q-mr-sm"
+                    @click="editModeEnabled = false"
+                  />
+                  <q-btn
+                    tnumberype="submit"
+                    :loading="submittingComment"
+                    color="primary"
+                    label="Save"
+                    @click="patchAnalystComment(vul.id.toString())"
+                  >
                     <template #loading>
                       <q-spinner-bars />
                     </template>
@@ -61,32 +74,50 @@ tnumberype="submit" :loading="submittingComment" color="primary" label="Save"
               <div class="text-muted">{{ vul.comment }}</div>
               <div class="row justify-end">
                 <q-btn
-class="q-mr-sm" color="warning" label="Edit" no-caps size="sm"
-                  @click="enableEditAnalystComment(vul.comment)" />
+                  class="q-mr-sm"
+                  color="warning"
+                  label="Edit"
+                  no-caps
+                  size="sm"
+                  @click="enableEditAnalystComment(vul.comment)"
+                />
                 <q-btn
-color="red-8" label="Delete" no-caps size="sm" :loading="deletingComment" class="qt-mt-md"
-                  @click="deleteAnalystComment(vul.id.toString())">
+                  color="red-8"
+                  label="Delete"
+                  no-caps
+                  size="sm"
+                  :loading="deletingComment"
+                  class="qt-mt-md"
+                  @click="deleteAnalystComment(vul.id.toString())"
+                >
                   <template #loading>
                     <q-spinner-bars />
                   </template>
                 </q-btn>
               </div>
-
             </template>
           </q-card-section>
           <q-card-section v-else-if="isAddingComment">
             <div class="text-title">Write an Analyst Comment</div>
             <div class="text-muted">
-              <q-input v-model="analystCommentText" hint="Type a comment" filled></q-input>
+              <q-input
+                v-model="analystCommentText"
+                hint="Type a comment"
+                filled
+              ></q-input>
               <div class="row justify-end">
                 <q-btn
-tnumberype="submit" :loading="submittingComment" color="primary" label="Add comment" size="sm"
-                  @click="submitAnalystComment(vul.id.toString())">
+                  tnumberype="submit"
+                  :loading="submittingComment"
+                  color="primary"
+                  label="Add comment"
+                  size="sm"
+                  @click="submitAnalystComment(vul.id.toString())"
+                >
                   <template #loading>
                     <q-spinner-bars />
                   </template>
                 </q-btn>
-
               </div>
             </div>
           </q-card-section>
@@ -95,7 +126,10 @@ tnumberype="submit" :loading="submittingComment" color="primary" label="Add comm
             <div class="text-title">Vendor Comments</div>
             <div class="text-muted">
               <div v-if="vul.vendor_comments">
-                <div v-for="comment in vul.vendor_comments" :key="comment.organization">
+                <div
+                  v-for="comment in vul.vendor_comments"
+                  :key="comment.organization"
+                >
                   <q-card-section>
                     <div class="text-title">{{ comment.organization }}</div>
                     <div class="text-muted">{{ comment.comment }}</div>
@@ -145,12 +179,17 @@ tnumberype="submit" :loading="submittingComment" color="primary" label="Add comm
           </q-card-section>
           <q-card-section v-if="detailView" align="right">
             <q-btn
-color="primary" label="Report" no-caps size="md" @click="
-              $router.push({
-                name: ROUTES_NAMES.reportsDetailVul,
-                params: { idvul: vul.id }
-              })
-              "></q-btn>
+              color="primary"
+              label="Report"
+              no-caps
+              size="md"
+              @click="
+                $router.push({
+                  name: ROUTES_NAMES.reportsDetailVul,
+                  params: { idvul: vul.id }
+                })
+              "
+            ></q-btn>
           </q-card-section>
         </div>
       </q-card>
@@ -159,230 +198,236 @@ color="primary" label="Report" no-caps size="md" @click="
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue';
-import { AxiosError } from 'axios';
-import { ScanVulnerability } from 'src/models';
-import { ROUTES_NAMES } from 'src/router/routes-names';
-import { VulnerabilitesService } from 'src/services';
-import { errorQuasarNotify, successQuasarNotify } from 'src/utils';
-import { onMounted, ref } from 'vue';
+  import { computed } from 'vue';
+  import { AxiosError } from 'axios';
+  import { ScanVulnerability } from 'src/models';
+  import { ROUTES_NAMES } from 'src/router/routes-names';
+  import { VulnerabilitesService } from 'src/services';
+  import { errorQuasarNotify, successQuasarNotify } from 'src/utils';
+  import { onMounted, ref } from 'vue';
 
-const props = defineProps({
-  vul: {
-    type: {} as () => ScanVulnerability,
-    required: true
-  },
-  detailView: {
-    type: Boolean,
-    default: () => true
-  }
-});
-
-const emit = defineEmits(['comment-updated']);
-
-const showInfo = ref(false);
-const analystCommentText = ref('')
-const submittingComment = ref(false);
-const deletingComment = ref(false);
-const editModeEnabled = ref(false);
-const editedAnalystCommentText = ref('');
-
-const hasComment = computed(() => !!props.vul.comment)
-const isEditingComment = computed(() => editModeEnabled.value && hasComment.value);
-const isAddingComment = computed(() => !hasComment.value);
-
-
-const cardColor = (cvss: number) => {
-  let color = '';
-  if (cvss > 0 && cvss < 3.9) color = 'green';
-  else if (cvss > 3.9 && cvss < 6.9) color = 'yellow';
-  else if (cvss > 6.9 && cvss < 9) color = 'orange';
-  else if (cvss >= 9) color = 'red';
-  return color;
-};
-
-function showInfoHandler(): void {
-  showInfo.value = !showInfo.value;
-}
-
-async function submitAnalystComment(vulnID: string) {
-  submittingComment.value = true
-
-  try {
-    await VulnerabilitesService.postVulnerabilityComment(vulnID, analystCommentText.value)
-    successQuasarNotify('Analyst Comment was submitted successfully.');
-    submittingComment.value = false
-    emit('comment-updated', analystCommentText.value);
-  } catch (error) {
-    const axiosError = error as AxiosError;
-    const errorData = axiosError.response?.data as
-      | { error?: string }
-      | undefined;
-
-    if (errorData?.error) {
-      errorQuasarNotify(errorData.error);
-    } else {
-      errorQuasarNotify('An unexpected error occurred.');
-      console.error('Error details:', error);
+  const props = defineProps({
+    vul: {
+      type: {} as () => ScanVulnerability,
+      required: true
+    },
+    detailView: {
+      type: Boolean,
+      default: () => true
     }
-    submittingComment.value = false
+  });
 
+  const emit = defineEmits(['comment-updated']);
+
+  const showInfo = ref(false);
+  const analystCommentText = ref('');
+  const submittingComment = ref(false);
+  const deletingComment = ref(false);
+  const editModeEnabled = ref(false);
+  const editedAnalystCommentText = ref('');
+
+  const hasComment = computed(() => !!props.vul.comment);
+  const isEditingComment = computed(
+    () => editModeEnabled.value && hasComment.value
+  );
+  const isAddingComment = computed(() => !hasComment.value);
+
+  const cardColor = (cvss: number) => {
+    let color = '';
+    if (cvss > 0 && cvss < 3.9) color = 'green';
+    else if (cvss > 3.9 && cvss < 6.9) color = 'yellow';
+    else if (cvss > 6.9 && cvss < 9) color = 'orange';
+    else if (cvss >= 9) color = 'red';
+    return color;
+  };
+
+  function showInfoHandler(): void {
+    showInfo.value = !showInfo.value;
   }
-}
 
-async function deleteAnalystComment(vulnID: string) {
-  deletingComment.value = true
+  async function submitAnalystComment(vulnID: string) {
+    submittingComment.value = true;
 
-  try {
-    await VulnerabilitesService.deleteVulnerabilityComment(vulnID);
-    successQuasarNotify('Analyst Comment was deleted successfully.');
-    deletingComment.value = false
-    emit('comment-updated', null);
-  } catch (error) {
-    const axiosError = error as AxiosError;
-    const errorData = axiosError.response?.data as
-      | { error?: string }
-      | undefined;
+    try {
+      await VulnerabilitesService.postVulnerabilityComment(
+        vulnID,
+        analystCommentText.value
+      );
+      successQuasarNotify('Analyst Comment was submitted successfully.');
+      submittingComment.value = false;
+      emit('comment-updated', analystCommentText.value);
+    } catch (error) {
+      const axiosError = error as AxiosError;
+      const errorData = axiosError.response?.data as
+        | { error?: string }
+        | undefined;
 
-    if (errorData?.error) {
-      errorQuasarNotify(errorData.error);
-    } else {
-      errorQuasarNotify('An unexpected error occurred.');
-      console.error('Error details:', error);
+      if (errorData?.error) {
+        errorQuasarNotify(errorData.error);
+      } else {
+        errorQuasarNotify('An unexpected error occurred.');
+        console.error('Error details:', error);
+      }
+      submittingComment.value = false;
     }
-    deletingComment.value = false
   }
-}
 
-function enableEditAnalystComment(vulnComment: string | undefined): void {
-  editModeEnabled.value = true;
-  editedAnalystCommentText.value = vulnComment || '';
-}
+  async function deleteAnalystComment(vulnID: string) {
+    deletingComment.value = true;
 
-async function patchAnalystComment(vulnID: string) {
-  submittingComment.value = true
+    try {
+      await VulnerabilitesService.deleteVulnerabilityComment(vulnID);
+      successQuasarNotify('Analyst Comment was deleted successfully.');
+      deletingComment.value = false;
+      emit('comment-updated', null);
+    } catch (error) {
+      const axiosError = error as AxiosError;
+      const errorData = axiosError.response?.data as
+        | { error?: string }
+        | undefined;
 
-  try {
-    await VulnerabilitesService.patchVulnerabilityComment(vulnID, editedAnalystCommentText.value)
-    successQuasarNotify('Analyst Comment was edited successfully.');
-    submittingComment.value = false;
-    editModeEnabled.value = false;
-    emit('comment-updated', {
-      vulID: parseInt(vulnID)
-      , newComment: editedAnalystCommentText.value
-    });
-  } catch (error) {
-    const axiosError = error as AxiosError;
-    const errorData = axiosError.response?.data as
-      | { error?: string }
-      | undefined;
-
-    if (errorData?.error) {
-      errorQuasarNotify(errorData.error);
-    } else {
-      errorQuasarNotify('An unexpected error occurred.');
-      console.error('Error details:', error);
+      if (errorData?.error) {
+        errorQuasarNotify(errorData.error);
+      } else {
+        errorQuasarNotify('An unexpected error occurred.');
+        console.error('Error details:', error);
+      }
+      deletingComment.value = false;
     }
-    submittingComment.value = false
-    editModeEnabled.value = false;
   }
-}
 
-onMounted(() => {
-  if (!props.detailView) {
-    showInfo.value = true;
+  function enableEditAnalystComment(vulnComment: string | undefined): void {
+    editModeEnabled.value = true;
+    editedAnalystCommentText.value = vulnComment || '';
   }
-});
+
+  async function patchAnalystComment(vulnID: string) {
+    submittingComment.value = true;
+
+    try {
+      await VulnerabilitesService.patchVulnerabilityComment(
+        vulnID,
+        editedAnalystCommentText.value
+      );
+      successQuasarNotify('Analyst Comment was edited successfully.');
+      submittingComment.value = false;
+      editModeEnabled.value = false;
+      emit('comment-updated', {
+        vulID: parseInt(vulnID),
+        newComment: editedAnalystCommentText.value
+      });
+    } catch (error) {
+      const axiosError = error as AxiosError;
+      const errorData = axiosError.response?.data as
+        | { error?: string }
+        | undefined;
+
+      if (errorData?.error) {
+        errorQuasarNotify(errorData.error);
+      } else {
+        errorQuasarNotify('An unexpected error occurred.');
+        console.error('Error details:', error);
+      }
+      submittingComment.value = false;
+      editModeEnabled.value = false;
+    }
+  }
+
+  onMounted(() => {
+    if (!props.detailView) {
+      showInfo.value = true;
+    }
+  });
 </script>
 
 <style lang="scss" scoped>
-.card {
-  &-vul {
-    background-color: #f6f7fc;
-    overflow-y: auto;
-  }
+  .card {
+    &-vul {
+      background-color: #f6f7fc;
+      overflow-y: auto;
+    }
 
-  &-yellow {
-    border-left: #fbbf65 10px solid;
-  }
+    &-yellow {
+      border-left: #fbbf65 10px solid;
+    }
 
-  &-red {
-    border-left: #e5494d 10px solid;
-  }
+    &-red {
+      border-left: #e5494d 10px solid;
+    }
 
-  &-green {
-    border-left: #97b951 10px solid;
-  }
+    &-green {
+      border-left: #97b951 10px solid;
+    }
 
-  &-orange {
-    border-left: #f3a488 10px solid;
-  }
-}
-
-.cvss {
-  &-yellow {
-    .value {
-      border: #fbbf65 1px solid;
-      background: #fbbf651a;
-      padding: 0 5px;
-      width: fit-content;
-      font-weight: 500;
-      color: black;
+    &-orange {
+      border-left: #f3a488 10px solid;
     }
   }
 
-  &-red {
-    .value {
-      border: #e5494d 1px solid;
-      background: #ed273d1a;
-      padding: 0 5px;
-      width: fit-content;
-      font-weight: 500;
-      color: black;
+  .cvss {
+    &-yellow {
+      .value {
+        border: #fbbf65 1px solid;
+        background: #fbbf651a;
+        padding: 0 5px;
+        width: fit-content;
+        font-weight: 500;
+        color: black;
+      }
+    }
+
+    &-red {
+      .value {
+        border: #e5494d 1px solid;
+        background: #ed273d1a;
+        padding: 0 5px;
+        width: fit-content;
+        font-weight: 500;
+        color: black;
+      }
+    }
+
+    &-green {
+      .value {
+        border: #97b951 1px solid;
+        background: #46a7581a;
+        padding: 0 5px;
+        width: fit-content;
+        font-weight: 500;
+        color: black;
+      }
+    }
+
+    &-orange {
+      .value {
+        border: #f3a488 1px solid;
+        background: #fbbf651a;
+        padding: 0 5px;
+        width: fit-content;
+        font-weight: 500;
+        color: black;
+      }
     }
   }
 
-  &-green {
-    .value {
-      border: #97b951 1px solid;
-      background: #46a7581a;
-      padding: 0 5px;
-      width: fit-content;
-      font-weight: 500;
-      color: black;
-    }
+  .text-title {
+    color: #313541;
+    font-weight: 700;
+    font-size: 16px;
   }
 
-  &-orange {
-    .value {
-      border: #f3a488 1px solid;
-      background: #fbbf651a;
-      padding: 0 5px;
-      width: fit-content;
-      font-weight: 500;
-      color: black;
-    }
+  .text-muted {
+    color: #5c7288;
+    font-size: 11px;
   }
-}
 
-.text-title {
-  color: #313541;
-  font-weight: 700;
-  font-size: 16px;
-}
+  .v-enter-active,
+  .v-leave-active {
+    transition: opacity 0.5s ease;
+  }
 
-.text-muted {
-  color: #5c7288;
-  font-size: 11px;
-}
-
-.v-enter-active,
-.v-leave-active {
-  transition: opacity 0.5s ease;
-}
-
-.v-enter-from,
-.v-leave-to {
-  opacity: 0;
-}
+  .v-enter-from,
+  .v-leave-to {
+    opacity: 0;
+  }
 </style>

--- a/src/components/report/VulnerabilityCard.vue
+++ b/src/components/report/VulnerabilityCard.vue
@@ -39,15 +39,16 @@
             <div class="text-title">Description</div>
             <div class="text-muted">{{ vul.description }}</div>
           </q-card-section>
-          <q-card-section v-if="vul.comment">
+
+          <q-card-section v-if="hasComment">
             <div class="text-title">Comment</div>
-            <template v-if="editModeEnabled">
+            <template v-if="isEditingComment">
               <div class="text-muted">
                 <q-input v-model="editedAnalystCommentText" hint="Type a comment" filled></q-input>
                 <div class="row justify-end">
-                  <q-btn label="Cancel" color="grey-9" @click="editModeEnabled = false" />
-                  <q-btn tnumberype="submit" :loading="submittingComment" color="primary" label="Submit"
-                    class="qt-mt-md" @click="patchAnalystComment(vul.id.toString())">
+                  <q-btn label="Cancel" color="grey-9" class="q-mr-sm" @click="editModeEnabled = false" />
+                  <q-btn tnumberype="submit" :loading="submittingComment" color="primary" label="Save"
+                    @click="patchAnalystComment(vul.id.toString())">
                     <template #loading>
                       <q-spinner-bars />
                     </template>
@@ -58,8 +59,9 @@
             <template v-else>
               <div class="text-muted">{{ vul.comment }}</div>
               <div class="row justify-end">
-                <q-btn color="warning" label="Edit" class="qt-mt-md" @click="enableEditAnalystComment(vul.comment)" />
-                <q-btn color="red-8" label="Delete" :loading="deletingComment" class="qt-mt-md"
+                <q-btn class="q-mr-sm" color="warning" label="Edit" no-caps size="sm"
+                  @click="enableEditAnalystComment(vul.comment)" />
+                <q-btn color="red-8" label="Delete" no-caps size="sm" :loading="deletingComment" class="qt-mt-md"
                   @click="deleteAnalystComment(vul.id.toString())">
                   <template #loading>
                     <q-spinner-bars />
@@ -69,13 +71,13 @@
 
             </template>
           </q-card-section>
-          <q-card-section v-else>
+          <q-card-section v-else-if="isAddingComment">
             <div class="text-title">Write an Analyst Comment</div>
             <div class="text-muted">
               <q-input v-model="analystCommentText" hint="Type a comment" filled></q-input>
               <div class="row justify-end">
-                <q-btn tnumberype="submit" :loading="submittingComment" color="primary" label="Add comment"
-                  class="qt-mt-md" @click="submitAnalystComment(vul.id.toString())">
+                <q-btn tnumberype="submit" :loading="submittingComment" color="primary" label="Add comment" size="sm"
+                  @click="submitAnalystComment(vul.id.toString())">
                   <template #loading>
                     <q-spinner-bars />
                   </template>
@@ -84,6 +86,7 @@
               </div>
             </div>
           </q-card-section>
+
           <q-card-section v-if="vul.recommendation">
             <div class="text-title">Recommendation</div>
             <div class="text-muted">{{ vul.recommendation }}</div>
@@ -133,6 +136,7 @@
 </template>
 
 <script setup lang="ts">
+import { computed } from 'vue';
 import { AxiosError } from 'axios';
 import { ScanVulnerability } from 'src/models';
 import { ROUTES_NAMES } from 'src/router/routes-names';
@@ -159,6 +163,11 @@ const submittingComment = ref(false);
 const deletingComment = ref(false);
 const editModeEnabled = ref(false);
 const editedAnalystCommentText = ref('');
+
+const hasComment = computed(() => !!props.vul.comment)
+const isEditingComment = computed(() => editModeEnabled.value && hasComment.value);
+const isAddingComment = computed(() => !hasComment.value);
+
 
 const cardColor = (cvss: number) => {
   let color = '';

--- a/src/components/report/VulnerabilityCard.vue
+++ b/src/components/report/VulnerabilityCard.vue
@@ -34,7 +34,7 @@
   <Transition>
     <template v-if="showInfo">
       <q-card flat :class="`card-vul card-${cardColor(vul.max_cvss)}`">
-        <div style="max-height: 700px">
+        <div style="max-height: 850px">
           <q-card-section v-if="vul.description">
             <div class="text-title">Description</div>
             <div class="text-muted">{{ vul.description }}</div>
@@ -47,7 +47,8 @@
                 <q-input v-model="editedAnalystCommentText" hint="Type a comment" filled></q-input>
                 <div class="row justify-end">
                   <q-btn label="Cancel" color="grey-9" class="q-mr-sm" @click="editModeEnabled = false" />
-                  <q-btn tnumberype="submit" :loading="submittingComment" color="primary" label="Save"
+                  <q-btn
+tnumberype="submit" :loading="submittingComment" color="primary" label="Save"
                     @click="patchAnalystComment(vul.id.toString())">
                     <template #loading>
                       <q-spinner-bars />
@@ -59,9 +60,11 @@
             <template v-else>
               <div class="text-muted">{{ vul.comment }}</div>
               <div class="row justify-end">
-                <q-btn class="q-mr-sm" color="warning" label="Edit" no-caps size="sm"
+                <q-btn
+class="q-mr-sm" color="warning" label="Edit" no-caps size="sm"
                   @click="enableEditAnalystComment(vul.comment)" />
-                <q-btn color="red-8" label="Delete" no-caps size="sm" :loading="deletingComment" class="qt-mt-md"
+                <q-btn
+color="red-8" label="Delete" no-caps size="sm" :loading="deletingComment" class="qt-mt-md"
                   @click="deleteAnalystComment(vul.id.toString())">
                   <template #loading>
                     <q-spinner-bars />
@@ -76,7 +79,8 @@
             <div class="text-muted">
               <q-input v-model="analystCommentText" hint="Type a comment" filled></q-input>
               <div class="row justify-end">
-                <q-btn tnumberype="submit" :loading="submittingComment" color="primary" label="Add comment" size="sm"
+                <q-btn
+tnumberype="submit" :loading="submittingComment" color="primary" label="Add comment" size="sm"
                   @click="submitAnalystComment(vul.id.toString())">
                   <template #loading>
                     <q-spinner-bars />
@@ -91,10 +95,7 @@
             <div class="text-title">Vendor Comments</div>
             <div class="text-muted">
               <div v-if="vul.vendor_comments">
-                <div
-                  v-for="comment in vul.vendor_comments"
-                  :key="comment.organization"
-                >
+                <div v-for="comment in vul.vendor_comments" :key="comment.organization">
                   <q-card-section>
                     <div class="text-title">{{ comment.organization }}</div>
                     <div class="text-muted">{{ comment.comment }}</div>
@@ -143,7 +144,8 @@
             </div>
           </q-card-section>
           <q-card-section v-if="detailView" align="right">
-            <q-btn color="primary" label="Report" no-caps size="md" @click="
+            <q-btn
+color="primary" label="Report" no-caps size="md" @click="
               $router.push({
                 name: ROUTES_NAMES.reportsDetailVul,
                 params: { idvul: vul.id }

--- a/src/components/report/VulnerabilityCard.vue
+++ b/src/components/report/VulnerabilityCard.vue
@@ -42,6 +42,14 @@
           <q-card-section v-if="vul.comment">
             <div class="text-title">Comment</div>
             <div class="text-muted">{{ vul.comment }}</div>
+            <div class="row justify-end">
+              <q-btn color="red-8" label="Delete" :loading="deletingComment" class="qt-mt-md"
+                @click="deleteAnalystComment(vul.id.toString())">
+                <template #loading>
+                  <q-spinner-bars />
+                </template>
+              </q-btn>
+            </div>
           </q-card-section>
           <q-card-section v-else>
             <div class="text-title">Write an Analyst Comment</div>
@@ -128,6 +136,7 @@ const props = defineProps({
 const showInfo = ref(false);
 const analystCommentText = ref('')
 const submittingComment = ref(false);
+const deletingComment = ref(false);
 
 const cardColor = (cvss: number) => {
   let color = '';
@@ -163,6 +172,29 @@ async function submitAnalystComment(vulnID: string) {
     }
     submittingComment.value = false
 
+  }
+}
+
+async function deleteAnalystComment(vulnID: string) {
+  deletingComment.value = true
+
+  try {
+    await VulnerabilitesService.deleteVulnerabilityComment(vulnID);
+    successQuasarNotify('Analyst Comment was deleted successfully.');
+    deletingComment.value = false
+  } catch (error) {
+    const axiosError = error as AxiosError;
+    const errorData = axiosError.response?.data as
+      | { error?: string }
+      | undefined;
+
+    if (errorData?.error) {
+      errorQuasarNotify(errorData.error);
+    } else {
+      errorQuasarNotify('An unexpected error occurred.');
+      console.error('Error details:', error);
+    }
+    deletingComment.value = false
   }
 }
 

--- a/src/components/report/VulnerabilityCard.vue
+++ b/src/components/report/VulnerabilityCard.vue
@@ -39,7 +39,7 @@
             <div class="text-title">Description</div>
             <div class="text-muted">{{ vul.description }}</div>
           </q-card-section>
-          <q-card-section v-if="vul.comment != null">
+          <q-card-section v-if="vul.comment">
             <div class="text-title">Comment</div>
             <template v-if="editModeEnabled">
               <div class="text-muted">
@@ -151,6 +151,8 @@ const props = defineProps({
   }
 });
 
+const emit = defineEmits(['comment-updated']);
+
 const showInfo = ref(false);
 const analystCommentText = ref('')
 const submittingComment = ref(false);
@@ -178,6 +180,7 @@ async function submitAnalystComment(vulnID: string) {
     await VulnerabilitesService.postVulnerabilityComment(vulnID, analystCommentText.value)
     successQuasarNotify('Analyst Comment was submitted successfully.');
     submittingComment.value = false
+    emit('comment-updated', analystCommentText.value);
   } catch (error) {
     const axiosError = error as AxiosError;
     const errorData = axiosError.response?.data as
@@ -202,6 +205,7 @@ async function deleteAnalystComment(vulnID: string) {
     await VulnerabilitesService.deleteVulnerabilityComment(vulnID);
     successQuasarNotify('Analyst Comment was deleted successfully.');
     deletingComment.value = false
+    emit('comment-updated', null);
   } catch (error) {
     const axiosError = error as AxiosError;
     const errorData = axiosError.response?.data as
@@ -231,6 +235,10 @@ async function patchAnalystComment(vulnID: string) {
     successQuasarNotify('Analyst Comment was edited successfully.');
     submittingComment.value = false;
     editModeEnabled.value = false;
+    emit('comment-updated', {
+      vulID: parseInt(vulnID)
+      , newComment: editedAnalystCommentText.value
+    });
   } catch (error) {
     const axiosError = error as AxiosError;
     const errorData = axiosError.response?.data as

--- a/src/pages/ReportDetailPage.vue
+++ b/src/pages/ReportDetailPage.vue
@@ -1,8 +1,13 @@
 <template>
   <Teleport v-if="isMounted" to="#header">
     <div class="q-py-sm">
-      <q-btn :label="`DOMAIN: ${vulnerabilities.alias}`" size="lg" flat icon="arrow_back"
-        @click="$router.push({ name: ROUTES_NAMES.reports })"></q-btn>
+      <q-btn
+        :label="`DOMAIN: ${vulnerabilities.alias}`"
+        size="lg"
+        flat
+        icon="arrow_back"
+        @click="$router.push({ name: ROUTES_NAMES.reports })"
+      ></q-btn>
     </div>
   </Teleport>
   <Teleport v-if="isMounted" to="#aux-sidebar">
@@ -44,120 +49,132 @@
     </div>
   </Teleport>
   <div class="row q-col-gutter-md q-px-md container">
-    <q-select v-model="sort" borderless dense :options="['Vulnerability', 'Cvss', 'Risk']"
-      @update:model-value="sortList"></q-select>
-    <div v-for="vul in vulnerabilities.vulnerabilities" :key="vul.id" class="col-12">
+    <q-select
+      v-model="sort"
+      borderless
+      dense
+      :options="['Vulnerability', 'Cvss', 'Risk']"
+      @update:model-value="sortList"
+    ></q-select>
+    <div
+      v-for="vul in vulnerabilities.vulnerabilities"
+      :key="vul.id"
+      class="col-12"
+    >
       <vulnerability-card :vul="vul" @comment-updated="handleCommentUpdated" />
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { ScanVulnerabilitesResponse, ScanVulnerability } from 'src/models';
-import { ReportService } from 'src/services';
-import { computed, onMounted, Ref, ref } from 'vue';
-import { useRoute } from 'vue-router';
-import { ROUTES_NAMES } from 'src/router/routes-names';
-import { useQuasar } from 'quasar';
-import VulnerabilityCard from 'src/components/report/VulnerabilityCard.vue';
+  import { ScanVulnerabilitesResponse, ScanVulnerability } from 'src/models';
+  import { ReportService } from 'src/services';
+  import { computed, onMounted, Ref, ref } from 'vue';
+  import { useRoute } from 'vue-router';
+  import { ROUTES_NAMES } from 'src/router/routes-names';
+  import { useQuasar } from 'quasar';
+  import VulnerabilityCard from 'src/components/report/VulnerabilityCard.vue';
 
-const route = useRoute();
-const scanId = route.params.id as string;
-const vulnerabilities: Ref<ScanVulnerabilitesResponse> = ref(
-  {} as ScanVulnerabilitesResponse
-);
-const sort = ref('Vulnerability');
-const isMounted = ref(false);
-const $q = useQuasar();
-
-const totalSeverity = computed(() => {
-  return Object.values(vulnerabilities.value.severity_counts).reduce(
-    (aux = 0, item) => (aux = aux + item)
+  const route = useRoute();
+  const scanId = route.params.id as string;
+  const vulnerabilities: Ref<ScanVulnerabilitesResponse> = ref(
+    {} as ScanVulnerabilitesResponse
   );
-});
+  const sort = ref('Vulnerability');
+  const isMounted = ref(false);
+  const $q = useQuasar();
 
-function handleCommentUpdated(payload: { vulID: number; newComment: string }) {
-  const vulnerabilityToUpdate = vulnerabilities.value.vulnerabilities.find(
-    (vul) => vul.id === payload.vulID
-  );
-
-  if (vulnerabilityToUpdate) {
-    vulnerabilityToUpdate.comment = payload.newComment;
-  } else {
-    console.warn(`Vulnerability with ID ${payload.vulID} not found.`)
-  }
-}
-
-function sortList(type: string): void {
-  let updatedList: ScanVulnerability[] = vulnerabilities.value.vulnerabilities;
-  if (type === 'Vulnerability') {
-    updatedList = vulnerabilities.value.vulnerabilities.sort((a, b) =>
-      b.name.localeCompare(a.name)
+  const totalSeverity = computed(() => {
+    return Object.values(vulnerabilities.value.severity_counts).reduce(
+      (aux = 0, item) => (aux = aux + item)
     );
-  }
-  if (type === 'Cvss') {
-    updatedList = vulnerabilities.value.vulnerabilities.sort(
-      (a, b) => b.max_cvss - a.max_cvss
-    );
-  }
-  if (type === 'Risk') {
-    updatedList = vulnerabilities.value.vulnerabilities.sort(
-      (a, b) => b.risk_score - a.risk_score
-    );
-  }
-  vulnerabilities.value.vulnerabilities = updatedList;
-}
+  });
 
-onMounted(async () => {
-  $q.loading.show();
-  vulnerabilities.value = (
-    await ReportService.getReportsVulnerabilities(scanId)
-  ).data;
-  $q.loading.hide();
-  sortList('Vulnerability');
-  isMounted.value = true;
-});
+  function handleCommentUpdated(payload: {
+    vulID: number;
+    newComment: string;
+  }) {
+    const vulnerabilityToUpdate = vulnerabilities.value.vulnerabilities.find(
+      vul => vul.id === payload.vulID
+    );
+
+    if (vulnerabilityToUpdate) {
+      vulnerabilityToUpdate.comment = payload.newComment;
+    } else {
+      console.warn(`Vulnerability with ID ${payload.vulID} not found.`);
+    }
+  }
+
+  function sortList(type: string): void {
+    let updatedList: ScanVulnerability[] =
+      vulnerabilities.value.vulnerabilities;
+    if (type === 'Vulnerability') {
+      updatedList = vulnerabilities.value.vulnerabilities.sort((a, b) =>
+        b.name.localeCompare(a.name)
+      );
+    }
+    if (type === 'Cvss') {
+      updatedList = vulnerabilities.value.vulnerabilities.sort(
+        (a, b) => b.max_cvss - a.max_cvss
+      );
+    }
+    if (type === 'Risk') {
+      updatedList = vulnerabilities.value.vulnerabilities.sort(
+        (a, b) => b.risk_score - a.risk_score
+      );
+    }
+    vulnerabilities.value.vulnerabilities = updatedList;
+  }
+
+  onMounted(async () => {
+    $q.loading.show();
+    vulnerabilities.value = (
+      await ReportService.getReportsVulnerabilities(scanId)
+    ).data;
+    $q.loading.hide();
+    sortList('Vulnerability');
+    isMounted.value = true;
+  });
 </script>
 
 <style lang="scss" scoped>
-.container {
-  max-height: 100%;
-  overflow: auto;
-}
-
-.card {
-
-  &-red,
-  &-orange,
-  &-yellow,
-  &-green {
-    border-radius: 4px;
-    width: fit-content;
-    padding: 2px 5px;
+  .container {
+    max-height: 100%;
+    overflow: auto;
   }
 
-  &-red {
-    border: 1px solid #e5494d;
-    background-color: #fa556a33;
-    color: #e5494d;
-  }
+  .card {
+    &-red,
+    &-orange,
+    &-yellow,
+    &-green {
+      border-radius: 4px;
+      width: fit-content;
+      padding: 2px 5px;
+    }
 
-  &-orange {
-    border: 1px solid #f3a488;
-    background: #f3a48833;
-    color: #f3a488;
-  }
+    &-red {
+      border: 1px solid #e5494d;
+      background-color: #fa556a33;
+      color: #e5494d;
+    }
 
-  &-yellow {
-    border: 1px solid #eaa237;
-    background: #f6be6333;
-    color: #eaa237;
-  }
+    &-orange {
+      border: 1px solid #f3a488;
+      background: #f3a48833;
+      color: #f3a488;
+    }
 
-  &-green {
-    border: 1px solid #46a758;
-    background: #46a75833;
-    color: #46a758;
+    &-yellow {
+      border: 1px solid #eaa237;
+      background: #f6be6333;
+      color: #eaa237;
+    }
+
+    &-green {
+      border: 1px solid #46a758;
+      background: #46a75833;
+      color: #46a758;
+    }
   }
-}
 </style>

--- a/src/pages/ReportDetailPage.vue
+++ b/src/pages/ReportDetailPage.vue
@@ -1,13 +1,8 @@
 <template>
   <Teleport v-if="isMounted" to="#header">
     <div class="q-py-sm">
-      <q-btn
-        :label="`DOMAIN: ${vulnerabilites.alias}`"
-        size="lg"
-        flat
-        icon="arrow_back"
-        @click="$router.push({ name: ROUTES_NAMES.reports })"
-      ></q-btn>
+      <q-btn :label="`DOMAIN: ${vulnerabilities.alias}`" size="lg" flat icon="arrow_back"
+        @click="$router.push({ name: ROUTES_NAMES.reports })"></q-btn>
     </div>
   </Teleport>
   <Teleport v-if="isMounted" to="#aux-sidebar">
@@ -18,7 +13,7 @@
           <span class="card-red">CRITICAL</span>
         </div>
         <div class="col-2 text-white text-weight-bold">
-          {{ vulnerabilites.severity_counts.critical }}
+          {{ vulnerabilities.severity_counts.critical }}
         </div>
       </div>
       <div class="row q-mb-sm">
@@ -26,19 +21,19 @@
           <span class="card-orange">HIGH</span>
         </div>
         <div class="col-2 text-white text-weight-bold">
-          {{ vulnerabilites.severity_counts.high }}
+          {{ vulnerabilities.severity_counts.high }}
         </div>
       </div>
       <div class="row q-mb-sm">
         <div class="col-10"><span class="card-yellow">MEDIUM</span></div>
         <div class="col-2 text-white text-weight-bold">
-          {{ vulnerabilites.severity_counts.medium }}
+          {{ vulnerabilities.severity_counts.medium }}
         </div>
       </div>
       <div class="row">
         <div class="col-10"><span class="card-green">LOW</span></div>
         <div class="col-2 text-white text-weight-bold">
-          {{ vulnerabilites.severity_counts.low }}
+          {{ vulnerabilities.severity_counts.low }}
         </div>
       </div>
       <q-separator class="q-my-sm text-white bg-white" />
@@ -49,115 +44,120 @@
     </div>
   </Teleport>
   <div class="row q-col-gutter-md q-px-md container">
-    <q-select
-      v-model="sort"
-      borderless
-      dense
-      :options="['Vulnerability', 'Cvss', 'Risk']"
-      @update:model-value="sortList"
-    ></q-select>
-    <div
-      v-for="vul in vulnerabilites.vulnerabilities"
-      :key="vul.id"
-      class="col-12"
-    >
-      <vulnerability-card :vul="vul" />
+    <q-select v-model="sort" borderless dense :options="['Vulnerability', 'Cvss', 'Risk']"
+      @update:model-value="sortList"></q-select>
+    <div v-for="vul in vulnerabilities.vulnerabilities" :key="vul.id" class="col-12">
+      <vulnerability-card :vul="vul" @comment-updated="handleCommentUpdated" />
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
-  import { ScanVulnerabilitesResponse, ScanVulnerability } from 'src/models';
-  import { ReportService } from 'src/services';
-  import { computed, onMounted, Ref, ref } from 'vue';
-  import { useRoute } from 'vue-router';
-  import { ROUTES_NAMES } from 'src/router/routes-names';
-  import { useQuasar } from 'quasar';
-  import VulnerabilityCard from 'src/components/report/VulnerabilityCard.vue';
+import { ScanVulnerabilitesResponse, ScanVulnerability } from 'src/models';
+import { ReportService } from 'src/services';
+import { computed, onMounted, Ref, ref } from 'vue';
+import { useRoute } from 'vue-router';
+import { ROUTES_NAMES } from 'src/router/routes-names';
+import { useQuasar } from 'quasar';
+import VulnerabilityCard from 'src/components/report/VulnerabilityCard.vue';
 
-  const route = useRoute();
-  const scanId = route.params.id as string;
-  const vulnerabilites: Ref<ScanVulnerabilitesResponse> = ref(
-    {} as ScanVulnerabilitesResponse
+const route = useRoute();
+const scanId = route.params.id as string;
+const vulnerabilities: Ref<ScanVulnerabilitesResponse> = ref(
+  {} as ScanVulnerabilitesResponse
+);
+const sort = ref('Vulnerability');
+const isMounted = ref(false);
+const $q = useQuasar();
+
+const totalSeverity = computed(() => {
+  return Object.values(vulnerabilities.value.severity_counts).reduce(
+    (aux = 0, item) => (aux = aux + item)
   );
-  const sort = ref('Vulnerability');
-  const isMounted = ref(false);
-  const $q = useQuasar();
+});
 
-  const totalSeverity = computed(() => {
-    return Object.values(vulnerabilites.value.severity_counts).reduce(
-      (aux = 0, item) => (aux = aux + item)
-    );
-  });
+function handleCommentUpdated(payload: { vulID: number; newComment: string }) {
+  const vulnerabilityToUpdate = vulnerabilities.value.vulnerabilities.find(
+    (vul) => vul.id === payload.vulID
+  );
 
-  function sortList(type: string): void {
-    let updatedList: ScanVulnerability[] = vulnerabilites.value.vulnerabilities;
-    if (type === 'Vulnerability') {
-      updatedList = vulnerabilites.value.vulnerabilities.sort((a, b) =>
-        b.name.localeCompare(a.name)
-      );
-    }
-    if (type === 'Cvss') {
-      updatedList = vulnerabilites.value.vulnerabilities.sort(
-        (a, b) => b.max_cvss - a.max_cvss
-      );
-    }
-    if (type === 'Risk') {
-      updatedList = vulnerabilites.value.vulnerabilities.sort(
-        (a, b) => b.risk_score - a.risk_score
-      );
-    }
-    vulnerabilites.value.vulnerabilities = updatedList;
+  if (vulnerabilityToUpdate) {
+    vulnerabilityToUpdate.comment = payload.newComment;
+  } else {
+    console.warn(`Vulnerability with ID ${payload.vulID} not found.`)
   }
+}
 
-  onMounted(async () => {
-    $q.loading.show();
-    vulnerabilites.value = (
-      await ReportService.getReportsVulnerabilities(scanId)
-    ).data;
-    $q.loading.hide();
-    sortList('Vulnerability');
-    isMounted.value = true;
-  });
+function sortList(type: string): void {
+  let updatedList: ScanVulnerability[] = vulnerabilities.value.vulnerabilities;
+  if (type === 'Vulnerability') {
+    updatedList = vulnerabilities.value.vulnerabilities.sort((a, b) =>
+      b.name.localeCompare(a.name)
+    );
+  }
+  if (type === 'Cvss') {
+    updatedList = vulnerabilities.value.vulnerabilities.sort(
+      (a, b) => b.max_cvss - a.max_cvss
+    );
+  }
+  if (type === 'Risk') {
+    updatedList = vulnerabilities.value.vulnerabilities.sort(
+      (a, b) => b.risk_score - a.risk_score
+    );
+  }
+  vulnerabilities.value.vulnerabilities = updatedList;
+}
+
+onMounted(async () => {
+  $q.loading.show();
+  vulnerabilities.value = (
+    await ReportService.getReportsVulnerabilities(scanId)
+  ).data;
+  $q.loading.hide();
+  sortList('Vulnerability');
+  isMounted.value = true;
+});
 </script>
 
 <style lang="scss" scoped>
-  .container {
-    max-height: 100%;
-    overflow: auto;
+.container {
+  max-height: 100%;
+  overflow: auto;
+}
+
+.card {
+
+  &-red,
+  &-orange,
+  &-yellow,
+  &-green {
+    border-radius: 4px;
+    width: fit-content;
+    padding: 2px 5px;
   }
 
-  .card {
-    &-red,
-    &-orange,
-    &-yellow,
-    &-green {
-      border-radius: 4px;
-      width: fit-content;
-      padding: 2px 5px;
-    }
-    &-red {
-      border: 1px solid #e5494d;
-      background-color: #fa556a33;
-      color: #e5494d;
-    }
-
-    &-orange {
-      border: 1px solid #f3a488;
-      background: #f3a48833;
-      color: #f3a488;
-    }
-
-    &-yellow {
-      border: 1px solid #eaa237;
-      background: #f6be6333;
-      color: #eaa237;
-    }
-
-    &-green {
-      border: 1px solid #46a758;
-      background: #46a75833;
-      color: #46a758;
-    }
+  &-red {
+    border: 1px solid #e5494d;
+    background-color: #fa556a33;
+    color: #e5494d;
   }
+
+  &-orange {
+    border: 1px solid #f3a488;
+    background: #f3a48833;
+    color: #f3a488;
+  }
+
+  &-yellow {
+    border: 1px solid #eaa237;
+    background: #f6be6333;
+    color: #eaa237;
+  }
+
+  &-green {
+    border: 1px solid #46a758;
+    background: #46a75833;
+    color: #46a758;
+  }
+}
 </style>

--- a/src/pages/ReportDetailVulnerability.vue
+++ b/src/pages/ReportDetailVulnerability.vue
@@ -1,21 +1,35 @@
 <template>
   <Teleport v-if="isMounted" to="#header">
     <div class="q-py-sm">
-      <q-btn :label="`DOMAIN: ${vulnerability.host?.alias}`" size="lg" flat icon="arrow_back" @click="
-        $router.push({
-          name: ROUTES_NAMES.reportsDetail,
-          params: { id: reportId }
-        })
-        "></q-btn>
+      <q-btn
+        :label="`DOMAIN: ${vulnerability.host?.alias}`"
+        size="lg"
+        flat
+        icon="arrow_back"
+        @click="
+          $router.push({
+            name: ROUTES_NAMES.reportsDetail,
+            params: { id: reportId }
+          })
+        "
+      ></q-btn>
     </div>
   </Teleport>
   <Teleport v-if="isMounted" to="#aux-sidebar">
-    <div style="background-color: #313541; height: 100%; overflow-y: auto" class="q-pa-md">
+    <div
+      style="background-color: #313541; height: 100%; overflow-y: auto"
+      class="q-pa-md"
+    >
       <p class="text-white text-h6">DETAILS</p>
 
       <q-list class="rounded-borders">
-        <q-expansion-item expand-separator label="DATE" dense header-style="padding:0;font-weight:600"
-          class="text-white vul-container">
+        <q-expansion-item
+          expand-separator
+          label="DATE"
+          dense
+          header-style="padding:0;font-weight:600"
+          class="text-white vul-container"
+        >
           <q-item class="vul-info">
             <span class="vul-title">Published : </span>
             <span class="vul-des"> {{ vulnerability.date?.published }}</span>
@@ -25,8 +39,13 @@
             <span class="vul-des"> {{ vulnerability.date?.last_updated }}</span>
           </q-item>
         </q-expansion-item>
-        <q-expansion-item expand-separator label="PLUGIN" dense class="text-white"
-          header-style="padding:0;font-weight:600">
+        <q-expansion-item
+          expand-separator
+          label="PLUGIN"
+          dense
+          class="text-white"
+          header-style="padding:0;font-weight:600"
+        >
           <q-item class="vul-info">
             <span class="vul-title">CPE :</span>
             <span class="vul-des"> {{ vulnerability.plugin?.cpe }}</span>
@@ -44,31 +63,45 @@
             <span class="vul-des"> {{ vulnerability.plugin?.family }}</span>
           </q-item>
         </q-expansion-item>
-        <q-expansion-item expand-separator label="VPR KEY D." dense class="text-white"
-          header-style="padding:0;font-weight:600">
+        <q-expansion-item
+          expand-separator
+          label="VPR KEY D."
+          dense
+          class="text-white"
+          header-style="padding:0;font-weight:600"
+        >
           <q-item class="vul-info">
             <span class="vul-title">Threat Intensity :</span>
             <span class="vul-des">
-              {{ vulnerability.vpr_key_d?.threat_intensity }}</span>
+              {{ vulnerability.vpr_key_d?.threat_intensity }}</span
+            >
           </q-item>
           <q-item class="vul-info">
             <span class="vul-title">Exploit Code Maturity :</span>
             <span class="vul-des">
-              {{ vulnerability.vpr_key_d?.exploit_code_maturity }}</span>
+              {{ vulnerability.vpr_key_d?.exploit_code_maturity }}</span
+            >
           </q-item>
           <q-item class="vul-info">
             <span class="vul-title">Age of Vul :</span>
             <span class="vul-des">
-              {{ vulnerability.vpr_key_d?.age_of_vuln }}</span>
+              {{ vulnerability.vpr_key_d?.age_of_vuln }}</span
+            >
           </q-item>
           <q-item class="vul-info">
             <span class="vul-title">Product Coverage :</span>
             <span class="vul-des">
-              {{ vulnerability.vpr_key_d?.product_coverage }}</span>
+              {{ vulnerability.vpr_key_d?.product_coverage }}</span
+            >
           </q-item>
         </q-expansion-item>
-        <q-expansion-item expand-separator label="RISK INFO" dense class="text-white"
-          header-style="padding:0;font-weight:600">
+        <q-expansion-item
+          expand-separator
+          label="RISK INFO"
+          dense
+          class="text-white"
+          header-style="padding:0;font-weight:600"
+        >
           <q-item class="vul-info">
             <span class="vul-title">Risk Score:</span>
             <span class="vul-des"> {{ vulnerability.risk?.risk_score }}</span>
@@ -76,12 +109,14 @@
           <q-item class="vul-info">
             <span class="vul-title">Availability Impact :</span>
             <span class="vul-des">
-              {{ vulnerability.risk?.availability_impact }}</span>
+              {{ vulnerability.risk?.availability_impact }}</span
+            >
           </q-item>
           <q-item class="vul-info">
             <span class="vul-title">Integrity Impact :</span>
             <span class="vul-des">
-              {{ vulnerability.risk?.integrity_impact }}</span>
+              {{ vulnerability.risk?.integrity_impact }}</span
+            >
           </q-item>
           <q-item class="vul-info">
             <span class="vul-title">CVSS v3 Base :</span>
@@ -90,66 +125,70 @@
           <q-item class="vul-info">
             <span class="vul-title">CVSS v3 Vector :</span>
             <span class="vul-des">
-              {{ vulnerability.risk?.cvss_v3_vector }}</span>
+              {{ vulnerability.risk?.cvss_v3_vector }}</span
+            >
           </q-item>
         </q-expansion-item>
       </q-list>
     </div>
   </Teleport>
-  <vulnerability-card :vul="vulnerability" :detail-view="false" @comment-updated="handleCommentUpdated" />
+  <vulnerability-card
+    :vul="vulnerability"
+    :detail-view="false"
+    @comment-updated="handleCommentUpdated"
+  />
 </template>
 
 <script setup lang="ts">
-import { ScanVulnerability } from 'src/models';
-import { VulnerabilitesService } from 'src/services';
-import { onMounted, Ref, ref } from 'vue';
-import { useRoute } from 'vue-router';
-import { ROUTES_NAMES } from 'src/router/routes-names';
-import VulnerabilityCard from 'src/components/report/VulnerabilityCard.vue';
+  import { ScanVulnerability } from 'src/models';
+  import { VulnerabilitesService } from 'src/services';
+  import { onMounted, Ref, ref } from 'vue';
+  import { useRoute } from 'vue-router';
+  import { ROUTES_NAMES } from 'src/router/routes-names';
+  import VulnerabilityCard from 'src/components/report/VulnerabilityCard.vue';
 
-const route = useRoute();
-const id = route.params.idvul as string;
-const reportId = route.params.id as string;
-const vulnerability: Ref<ScanVulnerability> = ref({} as ScanVulnerability);
-const isMounted = ref(false);
+  const route = useRoute();
+  const id = route.params.idvul as string;
+  const reportId = route.params.id as string;
+  const vulnerability: Ref<ScanVulnerability> = ref({} as ScanVulnerability);
+  const isMounted = ref(false);
 
-function handleCommentUpdated(payload: { newComment: string }) {
-  const vulnerabilityToUpdate = vulnerability.value;
+  function handleCommentUpdated(payload: { newComment: string }) {
+    const vulnerabilityToUpdate = vulnerability.value;
 
-  if (vulnerabilityToUpdate) {
-    vulnerabilityToUpdate.comment = payload.newComment;
-  } else {
-    console.warn('Vulnerability is null')
+    if (vulnerabilityToUpdate) {
+      vulnerabilityToUpdate.comment = payload.newComment;
+    } else {
+      console.warn('Vulnerability is null');
+    }
   }
-}
 
-
-onMounted(async () => {
-  vulnerability.value = (
-    await VulnerabilitesService.getVulnerabilitesById(id)
-  ).data;
-  isMounted.value = true;
-});
+  onMounted(async () => {
+    vulnerability.value = (
+      await VulnerabilitesService.getVulnerabilitesById(id)
+    ).data;
+    isMounted.value = true;
+  });
 </script>
 
 <style lang="scss">
-.vul-info {
-  padding: 0;
-  display: flex;
-  flex-direction: column;
-  margin: 0.5em 0;
+  .vul-info {
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    margin: 0.5em 0;
 
-  .vul-title {
-    font-weight: 600;
-    font-size: 15px;
-  }
+    .vul-title {
+      font-weight: 600;
+      font-size: 15px;
+    }
 
-  .vul-des {
-    text-wrap: revert;
-    word-break: break-all;
-    width: 100%;
-    font-weight: 100;
-    font-size: 13px;
+    .vul-des {
+      text-wrap: revert;
+      word-break: break-all;
+      width: 100%;
+      font-weight: 100;
+      font-size: 13px;
+    }
   }
-}
 </style>

--- a/src/pages/ReportDetailVulnerability.vue
+++ b/src/pages/ReportDetailVulnerability.vue
@@ -1,178 +1,155 @@
 <template>
   <Teleport v-if="isMounted" to="#header">
     <div class="q-py-sm">
-      <q-btn
-        :label="`DOMAIN: ${vulnerabilty.host?.alias}`"
-        size="lg"
-        flat
-        icon="arrow_back"
-        @click="
-          $router.push({
-            name: ROUTES_NAMES.reportsDetail,
-            params: { id: reportId }
-          })
-        "
-      ></q-btn>
+      <q-btn :label="`DOMAIN: ${vulnerability.host?.alias}`" size="lg" flat icon="arrow_back" @click="
+        $router.push({
+          name: ROUTES_NAMES.reportsDetail,
+          params: { id: reportId }
+        })
+        "></q-btn>
     </div>
   </Teleport>
   <Teleport v-if="isMounted" to="#aux-sidebar">
-    <div
-      style="background-color: #313541; height: 100%; overflow-y: auto"
-      class="q-pa-md"
-    >
+    <div style="background-color: #313541; height: 100%; overflow-y: auto" class="q-pa-md">
       <p class="text-white text-h6">DETAILS</p>
 
       <q-list class="rounded-borders">
-        <q-expansion-item
-          expand-separator
-          label="DATE"
-          dense
-          header-style="padding:0;font-weight:600"
-          class="text-white vul-container"
-        >
+        <q-expansion-item expand-separator label="DATE" dense header-style="padding:0;font-weight:600"
+          class="text-white vul-container">
           <q-item class="vul-info">
             <span class="vul-title">Published : </span>
-            <span class="vul-des"> {{ vulnerabilty.date?.published }}</span>
+            <span class="vul-des"> {{ vulnerability.date?.published }}</span>
           </q-item>
           <q-item class="vul-info">
             <span class="vul-title">Last Updated :</span>
-            <span class="vul-des"> {{ vulnerabilty.date?.last_updated }}</span>
+            <span class="vul-des"> {{ vulnerability.date?.last_updated }}</span>
           </q-item>
         </q-expansion-item>
-        <q-expansion-item
-          expand-separator
-          label="PLUGIN"
-          dense
-          class="text-white"
-          header-style="padding:0;font-weight:600"
-        >
+        <q-expansion-item expand-separator label="PLUGIN" dense class="text-white"
+          header-style="padding:0;font-weight:600">
           <q-item class="vul-info">
             <span class="vul-title">CPE :</span>
-            <span class="vul-des"> {{ vulnerabilty.plugin?.cpe }}</span>
+            <span class="vul-des"> {{ vulnerability.plugin?.cpe }}</span>
           </q-item>
           <q-item class="vul-info">
             <span class="vul-title">Severity :</span>
-            <span class="vul-des"> {{ vulnerabilty.plugin?.severity }}</span>
+            <span class="vul-des"> {{ vulnerability.plugin?.severity }}</span>
           </q-item>
           <q-item class="vul-info">
             <span class="vul-title">Version :</span>
-            <span class="vul-des"> {{ vulnerabilty.plugin?.version }}</span>
+            <span class="vul-des"> {{ vulnerability.plugin?.version }}</span>
           </q-item>
           <q-item class="vul-info">
             <span class="vul-title">Family :</span>
-            <span class="vul-des"> {{ vulnerabilty.plugin?.family }}</span>
+            <span class="vul-des"> {{ vulnerability.plugin?.family }}</span>
           </q-item>
         </q-expansion-item>
-        <q-expansion-item
-          expand-separator
-          label="VPR KEY D."
-          dense
-          class="text-white"
-          header-style="padding:0;font-weight:600"
-        >
+        <q-expansion-item expand-separator label="VPR KEY D." dense class="text-white"
+          header-style="padding:0;font-weight:600">
           <q-item class="vul-info">
             <span class="vul-title">Threat Intensity :</span>
             <span class="vul-des">
-              {{ vulnerabilty.vpr_key_d?.threat_intensity }}</span
-            >
+              {{ vulnerability.vpr_key_d?.threat_intensity }}</span>
           </q-item>
           <q-item class="vul-info">
             <span class="vul-title">Exploit Code Maturity :</span>
             <span class="vul-des">
-              {{ vulnerabilty.vpr_key_d?.exploit_code_maturity }}</span
-            >
+              {{ vulnerability.vpr_key_d?.exploit_code_maturity }}</span>
           </q-item>
           <q-item class="vul-info">
             <span class="vul-title">Age of Vul :</span>
             <span class="vul-des">
-              {{ vulnerabilty.vpr_key_d?.age_of_vuln }}</span
-            >
+              {{ vulnerability.vpr_key_d?.age_of_vuln }}</span>
           </q-item>
           <q-item class="vul-info">
             <span class="vul-title">Product Coverage :</span>
             <span class="vul-des">
-              {{ vulnerabilty.vpr_key_d?.product_coverage }}</span
-            >
+              {{ vulnerability.vpr_key_d?.product_coverage }}</span>
           </q-item>
         </q-expansion-item>
-        <q-expansion-item
-          expand-separator
-          label="RISK INFO"
-          dense
-          class="text-white"
-          header-style="padding:0;font-weight:600"
-        >
+        <q-expansion-item expand-separator label="RISK INFO" dense class="text-white"
+          header-style="padding:0;font-weight:600">
           <q-item class="vul-info">
             <span class="vul-title">Risk Score:</span>
-            <span class="vul-des"> {{ vulnerabilty.risk?.risk_score }}</span>
+            <span class="vul-des"> {{ vulnerability.risk?.risk_score }}</span>
           </q-item>
           <q-item class="vul-info">
             <span class="vul-title">Availability Impact :</span>
             <span class="vul-des">
-              {{ vulnerabilty.risk?.availability_impact }}</span
-            >
+              {{ vulnerability.risk?.availability_impact }}</span>
           </q-item>
           <q-item class="vul-info">
             <span class="vul-title">Integrity Impact :</span>
             <span class="vul-des">
-              {{ vulnerabilty.risk?.integrity_impact }}</span
-            >
+              {{ vulnerability.risk?.integrity_impact }}</span>
           </q-item>
           <q-item class="vul-info">
             <span class="vul-title">CVSS v3 Base :</span>
-            <span class="vul-des"> {{ vulnerabilty.risk?.cvss_v3_base }}</span>
+            <span class="vul-des"> {{ vulnerability.risk?.cvss_v3_base }}</span>
           </q-item>
           <q-item class="vul-info">
             <span class="vul-title">CVSS v3 Vector :</span>
             <span class="vul-des">
-              {{ vulnerabilty.risk?.cvss_v3_vector }}</span
-            >
+              {{ vulnerability.risk?.cvss_v3_vector }}</span>
           </q-item>
         </q-expansion-item>
       </q-list>
     </div>
   </Teleport>
-  <vulnerability-card :vul="vulnerabilty" :detail-view="false" />
+  <vulnerability-card :vul="vulnerability" :detail-view="false" @comment-updated="handleCommentUpdated" />
 </template>
 
 <script setup lang="ts">
-  import { ScanVulnerability } from 'src/models';
-  import { VulnerabilitesService } from 'src/services';
-  import { onMounted, Ref, ref } from 'vue';
-  import { useRoute } from 'vue-router';
-  import { ROUTES_NAMES } from 'src/router/routes-names';
-  import VulnerabilityCard from 'src/components/report/VulnerabilityCard.vue';
+import { ScanVulnerability } from 'src/models';
+import { VulnerabilitesService } from 'src/services';
+import { onMounted, Ref, ref } from 'vue';
+import { useRoute } from 'vue-router';
+import { ROUTES_NAMES } from 'src/router/routes-names';
+import VulnerabilityCard from 'src/components/report/VulnerabilityCard.vue';
 
-  const route = useRoute();
-  const id = route.params.idvul as string;
-  const reportId = route.params.id as string;
-  const vulnerabilty: Ref<ScanVulnerability> = ref({} as ScanVulnerability);
-  const isMounted = ref(false);
+const route = useRoute();
+const id = route.params.idvul as string;
+const reportId = route.params.id as string;
+const vulnerability: Ref<ScanVulnerability> = ref({} as ScanVulnerability);
+const isMounted = ref(false);
 
-  onMounted(async () => {
-    vulnerabilty.value = (
-      await VulnerabilitesService.getVulnerabilitesById(id)
-    ).data;
-    isMounted.value = true;
-  });
+function handleCommentUpdated(payload: { newComment: string }) {
+  const vulnerabilityToUpdate = vulnerability.value;
+
+  if (vulnerabilityToUpdate) {
+    vulnerabilityToUpdate.comment = payload.newComment;
+  } else {
+    console.warn('Vulnerability is null')
+  }
+}
+
+
+onMounted(async () => {
+  vulnerability.value = (
+    await VulnerabilitesService.getVulnerabilitesById(id)
+  ).data;
+  isMounted.value = true;
+});
 </script>
 
 <style lang="scss">
-  .vul-info {
-    padding: 0;
-    display: flex;
-    flex-direction: column;
-    margin: 0.5em 0;
-    .vul-title {
-      font-weight: 600;
-      font-size: 15px;
-    }
-    .vul-des {
-      text-wrap: revert;
-      word-break: break-all;
-      width: 100%;
-      font-weight: 100;
-      font-size: 13px;
-    }
+.vul-info {
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  margin: 0.5em 0;
+
+  .vul-title {
+    font-weight: 600;
+    font-size: 15px;
   }
+
+  .vul-des {
+    text-wrap: revert;
+    word-break: break-all;
+    width: 100%;
+    font-weight: 100;
+    font-size: 13px;
+  }
+}
 </style>

--- a/src/services/vulnerabilites.service.ts
+++ b/src/services/vulnerabilites.service.ts
@@ -10,4 +10,24 @@ export class VulnerabilitesService {
   ): Promise<AxiosResponse<ScanVulnerability>> {
     return await fusionAuthApi.get(`${this.BASE_PATH}/${id}`);
   }
+
+  static async postVulnerabilityComment(
+    id: string,
+    comment: string
+  ): Promise<AxiosResponse> {
+    return await fusionAuthApi.post(`${this.BASE_PATH}/${id}/comment`, { comment });
+  }
+
+  static async pathVulnerabilityComment(
+    id: string,
+    comment: string
+  ): Promise<AxiosResponse> {
+    return await fusionAuthApi.patch(`${this.BASE_PATH}/${id}/comment`, { comment });
+  }
+
+  static async deleteVulnerabilityComment(
+    id: string
+  ): Promise<AxiosResponse> {
+    return await fusionAuthApi.delete(`${this.BASE_PATH}/${id}/comment`)
+  }
 }

--- a/src/services/vulnerabilites.service.ts
+++ b/src/services/vulnerabilites.service.ts
@@ -15,19 +15,21 @@ export class VulnerabilitesService {
     id: string,
     comment: string
   ): Promise<AxiosResponse> {
-    return await fusionAuthApi.post(`${this.BASE_PATH}/${id}/comment`, { comment });
+    return await fusionAuthApi.post(`${this.BASE_PATH}/${id}/comment`, {
+      comment
+    });
   }
 
   static async patchVulnerabilityComment(
     id: string,
     comment: string
   ): Promise<AxiosResponse> {
-    return await fusionAuthApi.patch(`${this.BASE_PATH}/${id}/comment`, { comment });
+    return await fusionAuthApi.patch(`${this.BASE_PATH}/${id}/comment`, {
+      comment
+    });
   }
 
-  static async deleteVulnerabilityComment(
-    id: string
-  ): Promise<AxiosResponse> {
-    return await fusionAuthApi.delete(`${this.BASE_PATH}/${id}/comment`)
+  static async deleteVulnerabilityComment(id: string): Promise<AxiosResponse> {
+    return await fusionAuthApi.delete(`${this.BASE_PATH}/${id}/comment`);
   }
 }

--- a/src/services/vulnerabilites.service.ts
+++ b/src/services/vulnerabilites.service.ts
@@ -18,7 +18,7 @@ export class VulnerabilitesService {
     return await fusionAuthApi.post(`${this.BASE_PATH}/${id}/comment`, { comment });
   }
 
-  static async pathVulnerabilityComment(
+  static async patchVulnerabilityComment(
     id: string,
     comment: string
   ): Promise<AxiosResponse> {


### PR DESCRIPTION
## PR Description ✨

This PR introduces the **functionality for a user to create, edit and delete analyst comments for a vulnerability.**

- Added logic for dynamically displaying a vulnerability comment, which can be created (if it's empty initially), edited and deleted (if it's not empty).
- Defined a `comment-updated` emit on `VulnerabilityCard` to notify parent component that the comment was updated successfully. This way we prevent having to re-fetch all vulnerabilities after a reload.


### Caveats 📜

- These buttons and functionalities are shown to ANY kind of user at the moment. Ideally, we would conditionally show them based on the type of user that's logged in
- E.g: Only analyst users can Create, Edit and Destroy comments. Right now, both Analyst and Operator users can see buttons for these functionalities, but **an Operator user will receive errors if he attempts to perform them.**