### PR TITLE
[KT-453] : Host information does not auto-refresh after editing

### DIFF
--- a/src/components/Table/TableHost.vue
+++ b/src/components/Table/TableHost.vue
@@ -1,107 +1,115 @@
 <template>
   <q-btn label="New Host" color="primary" class="q-mb-md" @click="addHost"></q-btn>
   <div style="height: 80vh; overflow-y: auto">
-    <table-regular :actions="['edit', 'delete']" :columns="columns" :rows="rows" @action="handlerEmitter($event)" />
+    <table-regular
+      :actions="['edit', 'delete']"
+      :columns="columns"
+      :rows="rows"
+      @action="handlerEmitter($event)"
+    />
   </div>
 </template>
 
 <script setup lang="ts">
-import type { QTableColumn } from 'quasar';
-import { useQuasar } from 'quasar';
-import TableRegular from './TableRegular.vue';
-import DialogHost from '../Dialog/DialogHost.vue';
-import DialogEditHost from '../Dialog/DialogEditHost.vue';
-import { getHost, editHost } from 'src/services/host.service';
-import type { HostCreateBody } from 'src/models/hosts.models';
+  import type { QTableColumn } from 'quasar';
+  import { useQuasar } from 'quasar';
+  import TableRegular from './TableRegular.vue';
+  import DialogHost from '../Dialog/DialogHost.vue';
+  import DialogEditHost from '../Dialog/DialogEditHost.vue';
+  import { getHost, editHost } from 'src/services/host.service';
+  import type { HostCreateBody } from 'src/models/hosts.models';
 
-const props = defineProps<{
-  rows: Record<string, unknown>[];
-}>();
+  const props = defineProps<{
+    rows: Record<string, unknown>[];
+  }>();
 
-const emits = defineEmits(['refreshTable', 'action']);
+  const emits = defineEmits(['refreshTable', 'action']);
 
-const $q = useQuasar();
+  const $q = useQuasar();
 
-const columns: QTableColumn[] = [
-  {
-    name: 'Domain',
-    label: 'Domain',
-    align: 'left',
-    field: 'domain'
-  },
-  {
-    name: 'IP',
-    label: 'Ip',
-    align: 'left',
-    field: 'ip'
-  },
-  {
-    name: 'Host Name',
-    label: 'HostName',
-    align: 'left',
-    field: 'hostName'
-  },
-  {
-    name: 'Creation Date',
-    label: 'CreationDate',
-    align: 'left',
-    field: 'creationDate'
-  },
-  {
-    name: 'Email',
-    label: 'Email',
-    align: 'left',
-    field: 'email'
-  }
-];
-
-function addHost(): void {
-  $q.dialog({
-    component: DialogHost,
-    componentProps: {
-      hosts: props.rows
+  const columns: QTableColumn[] = [
+    {
+      name: 'Domain',
+      label: 'Domain',
+      align: 'left',
+      field: 'domain'
+    },
+    {
+      name: 'IP',
+      label: 'Ip',
+      align: 'left',
+      field: 'ip'
+    },
+    {
+      name: 'Host Name',
+      label: 'HostName',
+      align: 'left',
+      field: 'hostName'
+    },
+    {
+      name: 'Creation Date',
+      label: 'CreationDate',
+      align: 'left',
+      field: 'creationDate'
+    },
+    {
+      name: 'Email',
+      label: 'Email',
+      align: 'left',
+      field: 'email'
     }
-  })
-    .onOk(() => {
-      emits('refreshTable');
-    })
-    .onCancel(() => {
-      console.log('Cancel');
-    })
-    .onDismiss(() => {
-      console.log('Called on OK or Cancel');
-    });
-}
+  ];
 
-async function editHostHandler(col: unknown): Promise<void> {
-  const hostId = (col as { id: string }).id;
-  const host = (await getHost(hostId)).data;
-  $q.dialog({
-    component: DialogEditHost,
-    componentProps: {
-      host
-    }
-  })
-    .onOk((hostForm: HostCreateBody) => {
-      emits('refreshTable');
-      editHost(hostId, hostForm).catch((err) => new Error(err));
+  function addHost(): void {
+    $q.dialog({
+      component: DialogHost,
+      componentProps: {
+        hosts: props.rows
+      }
     })
-    .onCancel(() => {
-      console.log('Cancel');
-    })
-    .onDismiss(() => {
-      console.log('Called on OK or Cancel');
-    });
-}
-
-async function handlerEmitter(action: unknown): Promise<void> {
-  const actionType = action as { action: string; col: unknown };
-  if (actionType.action === 'edit') {
-    await editHostHandler(actionType.col);
-  } else {
-    emits('action', action);
+      .onOk(() => {
+        emits('refreshTable');
+      })
+      .onCancel(() => {
+        console.log('Cancel');
+      })
+      .onDismiss(() => {
+        console.log('Called on OK or Cancel');
+      });
   }
-}
+
+  async function editHostHandler(col: unknown): Promise<void> {
+    const hostId = (col as { id: string }).id;
+    const host = (await getHost(hostId)).data;
+    $q.dialog({
+      component: DialogEditHost,
+      componentProps: {
+        host
+      }
+    })
+      .onOk((hostForm: HostCreateBody) => {
+        editHost(hostId, hostForm)
+          .then(() => {
+            emits('refreshTable');
+          })
+          .catch(err => new Error(err));
+      })
+      .onCancel(() => {
+        console.log('Cancel');
+      })
+      .onDismiss(() => {
+        console.log('Called on OK or Cancel');
+      });
+  }
+
+  async function handlerEmitter(action: unknown): Promise<void> {
+    const actionType = action as { action: string; col: unknown };
+    if (actionType.action === 'edit') {
+      await editHostHandler(actionType.col);
+    } else {
+      emits('action', action);
+    }
+  }
 </script>
 
 <style scoped></style>


### PR DESCRIPTION
This pull request includes minor updates to the `TableHost.vue` component to improve code readability and fix the error handling in the `editHostHandler` function.

### Code readability improvements:
* Reformatted the `table-regular` component in the template for better readability by aligning its attributes vertically.

### Error handling fixes:
* Updated the `editHostHandler` function to ensure the `editHost` API call is properly chained with a `.then` block to emit a `refreshTable` event on success, and a `.catch` block for error handling. Previously, the error handling was incorrectly implemented.