### PR TITLE
FEAT : Add utils unit test

### DIFF
--- a/src/App.vitest.spec.ts
+++ b/src/App.vitest.spec.ts
@@ -1,0 +1,10 @@
+import { mount } from '@vue/test-utils';
+import { describe, it, expect } from 'vitest';
+import App from './App.vue'; // Adjust the import path as needed
+
+describe('App.vue', () => {
+  it('should render the router-view component', () => {
+    const wrapper = mount(App);
+    expect(wrapper.html()).toContain('<router-view></router-view>');
+  });
+});

--- a/src/utils/axios.utils.vitest.spec.ts
+++ b/src/utils/axios.utils.vitest.spec.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi } from 'vitest';
+import { getErrorMessage } from './axios.utils'; // Adjust the import path as needed
+import { i18n } from 'src/boot/i18n';
+
+// Mock the i18n object
+vi.mock('src/boot/i18n', () => ({
+  i18n: {
+    global: {
+      t: vi.fn((key: string) => `Translated: ${key}`) // Simple translation mock
+    }
+  }
+}));
+
+describe('getErrorMessage', () => {
+  it('should return the translated message for status code 400', () => {
+    expect(getErrorMessage(400)).toBe('Translated: api.error.messages.400');
+    expect(i18n.global.t).toHaveBeenCalledWith('api.error.messages.400');
+  });
+
+  it('should return the translated message for status code 401', () => {
+    expect(getErrorMessage(401)).toBe('Translated: api.error.messages.401');
+    expect(i18n.global.t).toHaveBeenCalledWith('api.error.messages.401');
+  });
+
+  it('should return the translated message for status code 403', () => {
+    expect(getErrorMessage(403)).toBe('Translated: api.error.messages.403');
+    expect(i18n.global.t).toHaveBeenCalledWith('api.error.messages.403');
+  });
+
+  it('should return the translated message for status code 404', () => {
+    expect(getErrorMessage(404)).toBe('Translated: api.error.messages.404');
+    expect(i18n.global.t).toHaveBeenCalledWith('api.error.messages.404');
+  });
+
+  it('should return the translated message for status code 405', () => {
+    expect(getErrorMessage(405)).toBe('Translated: api.error.messages.405');
+    expect(i18n.global.t).toHaveBeenCalledWith('api.error.messages.405');
+  });
+
+  it('should return the translated message for status code 409', () => {
+    expect(getErrorMessage(409)).toBe('Translated: api.error.messages.409');
+    expect(i18n.global.t).toHaveBeenCalledWith('api.error.messages.409');
+  });
+
+  it('should return the translated message for status code 429', () => {
+    expect(getErrorMessage(429)).toBe('Translated: api.error.messages.429');
+    expect(i18n.global.t).toHaveBeenCalledWith('api.error.messages.429');
+  });
+
+  it('should return the translated message for status code 500', () => {
+    expect(getErrorMessage(500)).toBe('Translated: api.error.messages.500');
+    expect(i18n.global.t).toHaveBeenCalledWith('api.error.messages.500');
+  });
+
+  it('should return the translated message for status code 502', () => {
+    expect(getErrorMessage(502)).toBe('Translated: api.error.messages.502');
+    expect(i18n.global.t).toHaveBeenCalledWith('api.error.messages.502');
+  });
+
+  it('should return the translated message for status code 503', () => {
+    expect(getErrorMessage(503)).toBe('Translated: api.error.messages.503');
+    expect(i18n.global.t).toHaveBeenCalledWith('api.error.messages.503');
+  });
+
+  it('should return the translated message for status code 504', () => {
+    expect(getErrorMessage(504)).toBe('Translated: api.error.messages.504');
+    expect(i18n.global.t).toHaveBeenCalledWith('api.error.messages.504');
+  });
+
+  it('should return the default translated message for an unknown status code', () => {
+    expect(getErrorMessage(999)).toBe('Translated: api.error.messages.default');
+    expect(i18n.global.t).toHaveBeenCalledWith('api.error.messages.default');
+  });
+
+  it('should still return a translation even if the specific key is missing (mock behavior)', () => {
+    (i18n.global.t as ReturnType<typeof vi.fn>).mockImplementation(
+      (key: string) => `Missing: ${key}`
+    );
+    expect(getErrorMessage(400)).toBe('Missing: api.error.messages.400');
+    expect(i18n.global.t).toHaveBeenCalledWith('api.error.messages.400');
+  });
+});

--- a/src/utils/host.utils.vitest.spec.ts
+++ b/src/utils/host.utils.vitest.spec.ts
@@ -1,0 +1,228 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import {
+  formatHostForTable,
+  getHostFromService,
+  getHostByIdFromService,
+  getInitalDataForHostTable,
+  getPrincipalRapporteur,
+  deleteHostById
+} from './host.utils';
+import type { Host, Rapporteur } from 'src/models/hosts.models';
+import { HostService } from 'src/services/host.service';
+import { useHosthStore } from 'src/stores/host-store';
+
+// Mock the HostService
+vi.mock('src/services/host.service', () => ({
+  HostService: {
+    getHosts: vi.fn(),
+    getHostById: vi.fn(),
+    deleteHostById: vi.fn()
+  }
+}));
+
+// Mock the host store
+vi.mock('src/stores/host-store', () => ({
+  useHosthStore: vi.fn(() => ({
+    setInitialList: vi.fn()
+  }))
+}));
+
+describe('host.utils', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('formatHostForTable', () => {
+    it('should correctly format an array of Hosts for a table', () => {
+      const mockHosts: Host[] = [
+        {
+          id: '1',
+          name: 'Server A',
+          created_at: '2023-01-15T10:00:00Z',
+          rapporteurs: [
+            { email: 'secondary@example.com', is_principal: false, name: 'test' },
+            { email: 'primary@example.com', is_principal: true, name: 'test' }
+          ],
+          credentials: []
+        },
+        {
+          id: '2',
+          name: 'Database B',
+          created_at: '2023-02-20T14:30:00Z',
+          rapporteurs: [{ email: 'single@test.com', is_principal: true, name: 'test' }],
+          credentials: []
+        },
+        {
+          id: '3',
+          name: 'API Gateway C',
+          created_at: '2023-03-01T08:00:00Z',
+          rapporteurs: [],
+          credentials: []
+        }
+      ];
+
+      const expectedFormattedHosts = [
+        {
+          id: '1',
+          name: 'Server A',
+          created_at: '2023-01-15T10:00:00Z',
+          rapporteurs: [
+            { email: 'secondary@example.com', is_principal: false, name: 'test' },
+            { email: 'primary@example.com', is_principal: true, name: 'test' }
+          ],
+          credentials: [],
+          hostName: 'Server A',
+          creationDate: '2023-01-15T10:00:00Z',
+          email: 'primary@example.com'
+        },
+        {
+          id: '2',
+          name: 'Database B',
+          created_at: '2023-02-20T14:30:00Z',
+          rapporteurs: [{ email: 'single@test.com', is_principal: true, name: 'test' }],
+          credentials: [],
+          hostName: 'Database B',
+          creationDate: '2023-02-20T14:30:00Z',
+          email: 'single@test.com'
+        },
+        {
+          id: '3',
+          name: 'API Gateway C',
+          created_at: '2023-03-01T08:00:00Z',
+          rapporteurs: [],
+          credentials: [],
+          hostName: 'API Gateway C',
+          creationDate: '2023-03-01T08:00:00Z',
+          email: ''
+        }
+      ];
+
+      expect(formatHostForTable(mockHosts)).toEqual(expectedFormattedHosts);
+    });
+
+    it('should return an empty array if the input array is empty', () => {
+      expect(formatHostForTable([])).toEqual([]);
+    });
+  });
+
+  describe('getHostFromService', () => {
+    it('should call HostService.getHosts and return the data', async () => {
+      const mockHostData: Host[] = [
+        {
+          id: '4',
+          name: 'Test Host',
+          created_at: '2023-04-01T12:00:00Z',
+          rapporteurs: [],
+          credentials: []
+        }
+      ];
+      (HostService.getHosts as ReturnType<typeof vi.fn>).mockResolvedValue({ data: mockHostData });
+
+      const result = await getHostFromService();
+      expect(HostService.getHosts).toHaveBeenCalledTimes(1);
+      expect(result).toEqual(mockHostData);
+    });
+  });
+
+  describe('getHostByIdFromService', () => {
+    it('should call HostService.getHostById with the provided hostId and return the data', async () => {
+      const mockHost: Host = {
+        credentials: [],
+        id: '5',
+        name: 'Specific Host',
+        created_at: '2023-05-05T18:00:00Z',
+        rapporteurs: [{ email: 'specific@host.com', is_principal: true, name: 'test' }]
+      };
+      (HostService.getHostById as ReturnType<typeof vi.fn>).mockResolvedValue({ data: mockHost });
+      const hostId = 'test-host-id';
+
+      const result = await getHostByIdFromService(hostId);
+      expect(HostService.getHostById).toHaveBeenCalledWith(hostId);
+      expect(result).toEqual(mockHost);
+    });
+  });
+
+  describe('getInitalDataForHostTable', () => {
+    it('should call HostService.getHosts and format the data for the table', async () => {
+      const mockHostDataFromService: Host[] = [
+        {
+          id: '6',
+          name: 'Service Host A',
+          created_at: '2023-06-10T09:00:00Z',
+          rapporteurs: [],
+          credentials: []
+        }
+      ];
+      (HostService.getHosts as ReturnType<typeof vi.fn>).mockResolvedValue({
+        data: mockHostDataFromService
+      });
+
+      const expectedFormattedData = [
+        {
+          id: '6',
+          name: 'Service Host A',
+          created_at: '2023-06-10T09:00:00Z',
+          rapporteurs: [],
+          credentials: [],
+          hostName: 'Service Host A',
+          creationDate: '2023-06-10T09:00:00Z',
+          email: ''
+        }
+      ];
+
+      const result = await getInitalDataForHostTable();
+      expect(HostService.getHosts).toHaveBeenCalledTimes(1);
+      expect(result).toEqual(expectedFormattedData);
+    });
+  });
+
+  describe('getPrincipalRapporteur', () => {
+    it('should return the email of the principal rapporteur if one exists', () => {
+      const rapporteurs: Rapporteur[] = [
+        { email: 'secondary@example.com', is_principal: false, name: 'test' },
+        { email: 'primary@example.com', is_principal: true, name: 'test' },
+        { email: 'another@test.com', is_principal: false, name: 'test' }
+      ];
+      expect(getPrincipalRapporteur(rapporteurs)).toBe('primary@example.com');
+    });
+
+    it('should return an empty string if no principal rapporteur exists', () => {
+      const rapporteurs: Rapporteur[] = [
+        { email: 'secondary@example.com', is_principal: false, name: 'test' },
+        { email: 'another@test.com', is_principal: false, name: 'test' }
+      ];
+      expect(getPrincipalRapporteur(rapporteurs)).toBe('');
+    });
+
+    it('should return an empty string if the rapporteurs array is empty', () => {
+      expect(getPrincipalRapporteur([])).toBe('');
+    });
+  });
+
+  describe('deleteHostById', () => {
+    it('should call HostService.deleteHostById and then setInitalDataToStore on success', async () => {
+      const hostIdToDelete = 'delete-me';
+      (HostService.deleteHostById as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+      (HostService.getHosts as ReturnType<typeof vi.fn>).mockResolvedValue({ data: [] }); // Mock getHosts for setInitalDataToStore
+
+      await deleteHostById(hostIdToDelete);
+      expect(HostService.deleteHostById).toHaveBeenCalledWith(hostIdToDelete);
+      expect(useHosthStore).toHaveBeenCalledTimes(1);
+    });
+
+    it('should log an error to the console if HostService.deleteHostById throws an error', async () => {
+      const hostIdToDelete = 'error-host';
+      const mockError = new Error('Failed to delete host');
+      (HostService.deleteHostById as ReturnType<typeof vi.fn>).mockRejectedValue(mockError);
+      const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      await deleteHostById(hostIdToDelete);
+      expect(HostService.deleteHostById).toHaveBeenCalledWith(hostIdToDelete);
+      expect(consoleLogSpy).toHaveBeenCalledWith(mockError);
+      expect(useHosthStore).not.toHaveBeenCalled(); // Ensure store is not updated on error
+
+      consoleLogSpy.mockRestore(); // Clean up the spy
+    });
+  });
+});

--- a/src/utils/insight.utils.vitest.spec.ts
+++ b/src/utils/insight.utils.vitest.spec.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import { getVariationIcon, getVulnerabilityList } from './insight.utils';
+import type { SeverityPerType, VulnerabilityItem } from 'src/models/scans.model';
+
+describe('getVariationIcon', () => {
+  it('should return the grey up arrow icon class for a variation of 0', () => {
+    expect(getVariationIcon(0)).toBe('fa-solid q-mx-sm text-grey fa-caret-up');
+  });
+
+  it('should return the green up arrow icon class for a positive variation', () => {
+    expect(getVariationIcon(5)).toBe('fa-solid q-mx-sm text-green fa-caret-up');
+  });
+
+  it('should return the red down arrow icon class for a negative variation', () => {
+    expect(getVariationIcon(-3)).toBe('fa-solid q-mx-sm text-red fa-caret-down');
+  });
+});
+
+describe('getVulnerabilityList', () => {
+  it('should transform a SeverityPerType object into an array of VulnerabilityItem', () => {
+    const vulnerabilities: SeverityPerType = {
+      Critical: '3',
+      High: '5',
+      Medium: '2',
+      Low: '1'
+    };
+    const expectedList: VulnerabilityItem[] = [
+      { id: 0, name: 'Critical', type: '3' },
+      { id: 1, name: 'High', type: '5' },
+      { id: 2, name: 'Medium', type: '2' },
+      { id: 3, name: 'Low', type: '1' }
+    ];
+    expect(getVulnerabilityList(vulnerabilities)).toEqual(expectedList);
+  });
+
+  it('should handle an empty SeverityPerType object', () => {
+    const vulnerabilities: SeverityPerType = {};
+    expect(getVulnerabilityList(vulnerabilities)).toEqual([]);
+  });
+
+  it('should handle SeverityPerType with zero values', () => {
+    const vulnerabilities: SeverityPerType = {
+      Critical: '0',
+      High: '0'
+    };
+    const expectedList: VulnerabilityItem[] = [
+      { id: 0, name: 'Critical', type: '0' },
+      { id: 1, name: 'High', type: '0' }
+    ];
+    expect(getVulnerabilityList(vulnerabilities)).toEqual(expectedList);
+  });
+
+  it('should use "None" as the type if the value is undefined', () => {
+    const vulnerabilities: SeverityPerType = {
+      Critical: '2',
+      Unknown: ''
+    } as SeverityPerType; // Type assertion to allow undefined
+    const expectedList: VulnerabilityItem[] = [
+      { id: 0, name: 'Critical', type: '2' },
+      { id: 1, name: 'Unknown', type: 'None' }
+    ];
+    expect(getVulnerabilityList(vulnerabilities)).toEqual(expectedList);
+  });
+});

--- a/src/utils/notify.utils.vitest.spec.ts
+++ b/src/utils/notify.utils.vitest.spec.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { Notify } from 'quasar';
+import { errorQuasarNotify, successQuasarNotify } from './notify.utils'; // Adjust the import path as needed
+import type { QNotifyPosition } from 'src/models/notify.models';
+
+// Mock the Quasar Notify object
+vi.mock('quasar', () => ({
+  Notify: {
+    create: vi.fn()
+  }
+}));
+
+describe('errorQuasarNotify', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should call Notify.create with the correct error configuration', () => {
+    const message = 'An error occurred.';
+    const icon = 'warning';
+    const position: QNotifyPosition = 'bottom';
+
+    errorQuasarNotify(message, icon, position);
+
+    expect(Notify.create).toHaveBeenCalledTimes(1);
+    expect(Notify.create).toHaveBeenCalledWith({
+      message,
+      color: 'negative',
+      icon,
+      position
+    });
+  });
+
+  it('should use the default icon and position if not provided', () => {
+    const message = 'Another error.';
+    errorQuasarNotify(message);
+
+    expect(Notify.create).toHaveBeenCalledTimes(1);
+    expect(Notify.create).toHaveBeenCalledWith({
+      message,
+      color: 'negative',
+      icon: 'error',
+      position: 'top-right'
+    });
+  });
+
+  it('should call Notify.create even if icon is not provided but position is', () => {
+    const message = 'Error with custom position.';
+    const position: QNotifyPosition = 'bottom-left';
+    errorQuasarNotify(message, undefined, position);
+
+    expect(Notify.create).toHaveBeenCalledTimes(1);
+    expect(Notify.create).toHaveBeenCalledWith({
+      message,
+      color: 'negative',
+      icon: 'error',
+      position
+    });
+  });
+});
+
+describe('successQuasarNotify', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should call Notify.create with the correct success configuration', () => {
+    const message = 'Operation successful!';
+    const icon = 'done';
+    const position: QNotifyPosition = 'bottom-right';
+
+    successQuasarNotify(message, icon, position);
+
+    expect(Notify.create).toHaveBeenCalledTimes(1);
+    expect(Notify.create).toHaveBeenCalledWith({
+      message,
+      color: 'positive',
+      icon,
+      position
+    });
+  });
+
+  it('should use the default icon and position if not provided', () => {
+    const message = 'Success message.';
+    successQuasarNotify(message);
+
+    expect(Notify.create).toHaveBeenCalledTimes(1);
+    expect(Notify.create).toHaveBeenCalledWith({
+      message,
+      color: 'positive',
+      icon: 'check_circle',
+      position: 'top-right'
+    });
+  });
+
+  it('should call Notify.create even if icon is not provided but position is', () => {
+    const message = 'Success with custom position.';
+    const position: QNotifyPosition = 'bottom-left';
+    successQuasarNotify(message, undefined, position);
+
+    expect(Notify.create).toHaveBeenCalledTimes(1);
+    expect(Notify.create).toHaveBeenCalledWith({
+      message,
+      color: 'positive',
+      icon: 'check_circle',
+      position
+    });
+  });
+});

--- a/src/utils/scan.utils.vitest.spec.ts
+++ b/src/utils/scan.utils.vitest.spec.ts
@@ -1,0 +1,219 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+import { describe, expect, it, vi } from 'vitest';
+import type { Scan, ScanInsight, ScanTableAction } from 'src/models/scans.model';
+import { ScanActions, ScanStatus } from 'src/models/scans.model';
+import { ScanService } from 'src/services';
+import {
+  formatScansForTable,
+  getScansFromService,
+  getScanInsightsFromService,
+  postScanCancelService,
+  formatDuration,
+  SCAN_TABLE_ACTIONS
+} from './scan.utils';
+
+// Mock the ScanService
+vi.mock('src/services', () => ({
+  ScanService: {
+    getScans: vi.fn(),
+    getScanInsights: vi.fn(),
+    cancelScan: vi.fn()
+  }
+}));
+
+describe('formatScansForTable', () => {
+  it('should correctly format an array of Scans for a QTable', () => {
+    const mockScans: Scan[] = [
+      {
+        scan_id: '1',
+        scan_date: '2023-01-01',
+        host: 'localhost',
+        vulnerabilities: 5,
+        severities: { critical: 2, high: 3, medium: 0, low: 0 },
+        duration: 120,
+        status: ScanStatus.completed
+      },
+      {
+        scan_id: '2',
+        scan_date: '2023-01-02',
+        host: 'example.com',
+        vulnerabilities: 10,
+        severities: { critical: 1, high: 4, medium: 3, low: 2 },
+        duration: 300,
+        status: ScanStatus.inProgress
+      }
+    ];
+
+    const expectedFormattedScans = [
+      {
+        id: '1',
+        scanDate: '2023-01-01',
+        host: 'localhost',
+        numVulnerabilities: 5,
+        severity: { critical: 2, high: 3, medium: 0, low: 0 },
+        durations: 120,
+        status: ScanStatus.completed
+      },
+      {
+        id: '2',
+        scanDate: '2023-01-02',
+        host: 'example.com',
+        numVulnerabilities: 10,
+        severity: { critical: 1, high: 4, medium: 3, low: 2 },
+        durations: 300,
+        status: ScanStatus.inProgress
+      }
+    ];
+
+    expect(formatScansForTable(mockScans)).toEqual(expectedFormattedScans);
+  });
+
+  it('should return an empty array if the input array is empty', () => {
+    expect(formatScansForTable([])).toEqual([]);
+  });
+});
+
+describe('getScansFromService', () => {
+  it('should call ScanService.getScans and return the data', async () => {
+    const mockScanData: Scan[] = [
+      {
+        scan_id: '3',
+        scan_date: '2023-01-03',
+        host: 'test.local',
+        vulnerabilities: 2,
+        severities: { critical: 0, high: 0, medium: 1, low: 1 },
+        duration: 60,
+        status: ScanStatus.completed
+      }
+    ];
+    (ScanService.getScans as ReturnType<typeof vi.fn>).mockResolvedValue({ data: mockScanData });
+
+    const result = await getScansFromService();
+
+    expect(ScanService.getScans).toHaveBeenCalledTimes(1);
+    expect(result).toEqual(mockScanData);
+  });
+});
+
+describe('getScanInsightsFromService', () => {
+  const mockInsightData: ScanInsight = {
+    total_vulnerabilities: 15,
+    vulnerabilities_by_severity: { critical: 3, high: 5, medium: 4, low: 3 },
+    severity_counts: {
+      critical: 1,
+      high: 1,
+      medium: 1,
+      low: 1
+    },
+    protection_score: 1,
+    severity_per_type: { val: '2' },
+    vulnerability_variation: 1,
+    protection_score_variation: 1,
+    metadata: {
+      scan_id: '1',
+      host_alias: '1',
+      scan_date: '1'
+    }
+  } as ScanInsight;
+
+  it('should call ScanService.getScanInsights with the provided scan_id and return the data', async () => {
+    (ScanService.getScanInsights as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: mockInsightData
+    });
+    const scanId = 'test-scan-id';
+
+    const result = await getScanInsightsFromService(scanId);
+    expect(ScanService.getScanInsights).toHaveBeenCalledWith(scanId);
+    expect(result).toEqual(mockInsightData);
+  });
+
+  it('should call ScanService.getScanInsights with an empty string if no scan_id is provided', async () => {
+    (ScanService.getScanInsights as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: mockInsightData
+    });
+
+    await getScanInsightsFromService();
+    expect(ScanService.getScanInsights).toHaveBeenCalledWith('');
+  });
+});
+
+describe('postScanCancelService', () => {
+  it('should call ScanService.cancelScan with the provided scan_id and return the data', async () => {
+    const mockCancelResponse = 'Scan cancellation initiated.';
+    (ScanService.cancelScan as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: mockCancelResponse
+    });
+    const scanId = 'cancel-scan-id';
+
+    const result = await postScanCancelService(scanId);
+    expect(ScanService.cancelScan).toHaveBeenCalledWith(scanId);
+    expect(result).toEqual(mockCancelResponse);
+  });
+
+  it('should call ScanService.cancelScan with an empty string if no scan_id is provided', async () => {
+    const mockCancelResponse = 'No scan ID provided for cancellation.';
+    (ScanService.cancelScan as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: mockCancelResponse
+    });
+
+    const result = await postScanCancelService();
+    expect(ScanService.cancelScan).toHaveBeenCalledWith('');
+    expect(result).toEqual(mockCancelResponse);
+  });
+});
+
+describe('formatDuration', () => {
+  it('should format duration in seconds correctly', () => {
+    expect(formatDuration(30)).toBe('30s');
+  });
+
+  it('should format duration in minutes and seconds correctly', () => {
+    expect(formatDuration(90)).toBe('1m 30s');
+  });
+
+  it('should format duration in hours and minutes correctly', () => {
+    expect(formatDuration(3660)).toBe('1h 1m');
+  });
+
+  it('should format duration in hours, minutes, and seconds correctly', () => {
+    expect(formatDuration(3725)).toBe('1h 2m');
+  });
+
+  it('should handle zero seconds correctly', () => {
+    expect(formatDuration(0)).toBe('0s');
+  });
+
+  it('should handle durations less than a minute correctly', () => {
+    expect(formatDuration(59)).toBe('59s');
+  });
+
+  it('should handle durations less than an hour correctly', () => {
+    expect(formatDuration(3599)).toBe('59m 59s');
+  });
+});
+
+describe('SCAN_TABLE_ACTIONS', () => {
+  it('should define the correct actions for the scan table', () => {
+    const expectedActions: ScanTableAction[] = [
+      { name: ScanActions.insight, icon: 'fas fa-chart-simple', show: expect.any(Function) },
+      { name: ScanActions.cancel, icon: 'close', show: expect.any(Function) }
+    ];
+    expect(SCAN_TABLE_ACTIONS).toEqual(expectedActions);
+  });
+
+  it('the "insight" action should be visible only when the status is "completed"', () => {
+    const insightAction = SCAN_TABLE_ACTIONS.find(action => action.name === ScanActions.insight);
+    expect(insightAction?.show(ScanStatus.completed)).toBe(true);
+    expect(insightAction?.show(ScanStatus.inProgress)).toBe(false);
+    expect(insightAction?.show(ScanStatus.pending)).toBe(false);
+    expect(insightAction?.show(ScanStatus.cancelled)).toBe(false);
+  });
+
+  it('the "cancel" action should be visible when the status is "inProgress" or "pending"', () => {
+    const cancelAction = SCAN_TABLE_ACTIONS.find(action => action.name === ScanActions.cancel);
+    expect(cancelAction?.show(ScanStatus.completed)).toBe(false);
+    expect(cancelAction?.show(ScanStatus.inProgress)).toBe(true);
+    expect(cancelAction?.show(ScanStatus.pending)).toBe(true);
+    expect(cancelAction?.show(ScanStatus.cancelled)).toBe(false);
+  });
+});


### PR DESCRIPTION
This pull request introduces unit tests for various utility functions across multiple files, enhancing test coverage and ensuring the correctness of the utility logic. The changes include adding tests for Vue components, error handling, data formatting, and service interactions.

### Added Unit Tests for Utility Functions:

#### Vue Component Testing:
* Added a test for `App.vue` to verify that the `router-view` component is rendered correctly. (`src/App.vitest.spec.ts`)

#### Axios Utility Testing:
* Added tests for `getErrorMessage` to ensure proper translation of error messages based on HTTP status codes, including mocking the `i18n` object for translations. (`src/utils/axios.utils.vitest.spec.ts`)

#### Host Utility Testing:
* Added comprehensive tests for various `host.utils` functions, including:
  - Formatting host data for tables.
  - Fetching host data from services.
  - Handling principal rapporteurs.
  - Deleting hosts and updating the store. (`src/utils/host.utils.vitest.spec.ts`)

#### Insight Utility Testing:
* Added tests for `getVariationIcon` and `getVulnerabilityList` to verify the correct transformation of severity data and icon selection based on variation values. (`src/utils/insight.utils.vitest.spec.ts`)

#### Notification Utility Testing:
* Added tests for `errorQuasarNotify` and `successQuasarNotify` to validate the correct configurations for Quasar notifications, including default values. (`src/utils/notify.utils.vitest.spec.ts`)

#### Scan Utility Testing:
* Added tests for `scan.utils` functions, including:
  - Formatting scan data for tables.
  - Fetching scan data and insights from services.
  - Cancelling scans and formatting durations.
  - Verifying the visibility logic of scan table actions. (`src/utils/scan.utils.vitest.spec.ts`)