### PR TITLE
feat: Add pr-lint for github [KT-456]

### DIFF
--- a/.github/workflows/pr-lint-config.json
+++ b/.github/workflows/pr-lint-config.json
@@ -1,0 +1,15 @@
+{
+  "LABEL": {
+    "name": "help wanted",
+    "color": "006B75"
+  },
+  "CHECKS": {
+    "regexp": "^(feat|fix|chore|docs): .+ \\[KT-\\d+\\]$",
+    "ignoreLabels": ["Sync Back", "dependabot", "dependencies"]
+  },
+  "MESSAGES": {
+    "success": "Title follows the specification.",
+    "failure": "PR title has to be in the format: 'feat: description [KT-1234]'.",
+    "notice": ""
+  }
+}

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -1,4 +1,7 @@
 name: Check PR title
+permissions:
+  contents: read
+  pull-requests: read
 on:
   pull_request:
     types:

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -1,0 +1,17 @@
+name: Check PR title
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - edited
+      - synchronize
+
+jobs:
+  pr_title_lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: thehanimo/pr-title-checker@v1.4.2
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          configuration_path: .github/workflows/pr-lint-config.json


### PR DESCRIPTION
This pull request introduces a new workflow to enforce consistent pull request title formatting by adding a PR title linting configuration and workflow file. The most important changes are as follows:

### Addition of PR title linting configuration:

* [`.github/workflows/pr-lint-config.json`](diffhunk://#diff-401d5ad16a24b8c5b73441fd9cd24077d8ed9fd39a88353f2014d2fe9ab0573fR1-R15): Added a configuration file specifying the required PR title format, labels to ignore, and success/failure messages. Titles must follow the pattern `^(feat|fix|chore|docs): .+ \[KT-\d+\].

### Addition of PR title linting workflow:

* [`.github/workflows/pr-lint.yml`](diffhunk://#diff-96c941d62860ad493e2ef6e2e641b5cdda1373729143a0a72a44f11f46895e4dR1-R17): Added a GitHub Actions workflow that triggers on pull request events (e.g., opened, edited, synchronized) to validate PR titles using the `pr-title-checker` action.