### PR TITLE
feat:  Implement Scan Assets View [KT-509]

### DIFF
--- a/src/modules/vulnerability/components/card/ReportServiceCard.vue
+++ b/src/modules/vulnerability/components/card/ReportServiceCard.vue
@@ -52,7 +52,7 @@
               <div class="title">{{ service.name }}</div>
               <div class="row">
                 <div class="col-6">
-                  <div class="row q-pl-lg flex-1 items-center">
+                  <div class="row q-pl-lg flex-1 items-center q-col-gutter-x-md">
                     <div class="col-3 text-weight-medium">
                       {{ $t('report.vulnerabilityCategory.portNumber') }}
                     </div>
@@ -60,7 +60,7 @@
                   </div>
                 </div>
                 <div class="col-6">
-                  <div class="row q-pl-lg flex-1 items-center">
+                  <div class="row q-pl-lg flex-1 items-center q-col-gutter-x-md">
                     <div class="col-3 text-weight-medium">
                       {{ $t('report.vulnerabilityCategory.protocol') }}
                     </div>
@@ -68,7 +68,7 @@
                   </div>
                 </div>
                 <div class="col-6">
-                  <div class="row q-pl-lg flex-1 items-center">
+                  <div class="row q-pl-lg flex-1 items-center q-col-gutter-x-md">
                     <div class="col-3 text-weight-medium">
                       {{ $t('report.vulnerabilityCategory.version') }}
                     </div>
@@ -76,7 +76,7 @@
                   </div>
                 </div>
                 <div class="col-6">
-                  <div class="row q-pl-lg flex-1 items-center">
+                  <div class="row q-pl-lg flex-1 items-center q-col-gutter-x-md">
                     <div class="col-3 text-weight-medium">
                       {{ $t('report.vulnerabilityCategory.detectedBanner') }}
                     </div>

--- a/src/modules/vulnerability/components/card/ReportServiceCard.vue
+++ b/src/modules/vulnerability/components/card/ReportServiceCard.vue
@@ -16,7 +16,7 @@
               <div class="col-3 text-weight-medium">
                 {{ $t('report.vulnerabilityCategory.precision') }}
               </div>
-              <div class="col">{{ assets.operating_system?.accuracy }}</div>
+              <div class="col">{{ assets.operating_system?.accuracy }} %</div>
             </div>
           </div>
         </q-card-section>

--- a/src/modules/vulnerability/components/card/ReportServiceCard.vue
+++ b/src/modules/vulnerability/components/card/ReportServiceCard.vue
@@ -1,124 +1,150 @@
 <template>
-  <q-card flat class="bg-grey-2 q-pa-sm" style="border-radius: 1em">
-    <q-card-section horizontal class="justify-between">
-      <q-card-section class="col-6 flex column">
-        <div class="title">{{ vulnerabilityGroup.name }}</div>
-        <div class="flex-1 flex column">
-          <template v-if="category === ReportVulnerabilityGroupCategory.OS">
+  <div style="height: 85vh; overflow: auto">
+    <h5 class="q-ma-none q-mb-sm text-weight-medium">Operating System</h5>
+    <q-card flat class="bg-grey-2 q-pa-sm" style="border-radius: 1em">
+      <q-card-section horizontal class="justify-between">
+        <q-card-section class="col-6 flex column">
+          <div class="title">{{ assets.operating_system?.name || '' }}</div>
+          <div class="flex-1 flex column">
             <div class="row q-pl-lg q-mt-sm">
               <div class="col-3 text-weight-medium">
                 {{ $t('report.vulnerabilityCategory.version') }}
               </div>
-              <div class="col">{{ vulnerabilityGroup.version }}</div>
+              <div class="col">{{ assets.operating_system?.version }}</div>
             </div>
             <div class="row q-pl-lg flex-1 items-center">
               <div class="col-3 text-weight-medium">
                 {{ $t('report.vulnerabilityCategory.precision') }}
               </div>
-              <div class="col">{{ vulnerabilityGroup.precision }}</div>
+              <div class="col">{{ assets.operating_system?.accuracy }}</div>
             </div>
-          </template>
-          <template v-else-if="category === ReportVulnerabilityGroupCategory.SERVICE">
-            <div class="row">
-              <div class="col-6">
-                <div class="row q-pl-lg flex-1 items-center">
-                  <div class="col-3 text-weight-medium">
-                    {{ $t('report.vulnerabilityCategory.portNumber') }}
-                  </div>
-                  <div class="col">{{ vulnerabilityGroup.portNumber }}</div>
-                </div>
-              </div>
-              <div class="col-6">
-                <div class="row q-pl-lg flex-1 items-center">
-                  <div class="col-3 text-weight-medium">
-                    {{ $t('report.vulnerabilityCategory.protocol') }}
-                  </div>
-                  <div class="col">{{ vulnerabilityGroup.protocol }}</div>
-                </div>
-              </div>
-              <div class="col-6">
-                <div class="row q-pl-lg flex-1 items-center">
-                  <div class="col-3 text-weight-medium">
-                    {{ $t('report.vulnerabilityCategory.version') }}
-                  </div>
-                  <div class="col">{{ vulnerabilityGroup.version }}</div>
-                </div>
-              </div>
-              <div class="col-6">
-                <div class="row q-pl-lg flex-1 items-center">
-                  <div class="col-3 text-weight-medium">
-                    {{ $t('report.vulnerabilityCategory.detectedBanner') }}
-                  </div>
-                  <div class="col">{{ vulnerabilityGroup.detectedBanner }}</div>
-                </div>
-              </div>
-            </div>
-          </template>
-        </div>
-      </q-card-section>
-      <q-separator vertical />
-      <q-card-section class="col-6 position-relative">
-        <q-btn
-          square
-          size="md"
-          flat
-          dense
-          icon="exit_to_app"
-          class="exit-button"
-          @click="goVulnerabilityTypeList"
-        ></q-btn>
-        <div class="title">{{ $t('report.vulnerabilityCategory.details') }}</div>
-        <div class="row text-center full-width">
-          <div class="col-12 text-weight-bold text-body1">{{ totalCountVulnerabilities }}</div>
-          <div class="col-12 text-body2">
-            {{ $t('report.vulnerabilityCategory.vulnerabilities') }}
           </div>
-        </div>
-        <div class="row q-pa-none q-pt-md">
-          <template v-for="level in vulnerabilityLevels" :key="level">
-            <div class="vulnerability-count col" :class="level.toLocaleLowerCase()">
-              {{ vulnerabilityGroup[level] }}
+        </q-card-section>
+
+        <q-separator vertical />
+        <q-card-section class="col-6 position-relative">
+          <q-btn square size="md" flat dense icon="exit_to_app" class="exit-button"></q-btn>
+          <div class="title">{{ $t('report.vulnerabilityCategory.details') }}</div>
+          <div class="row text-center full-width">
+            <div class="col-12 text-weight-bold text-body1">
+              {{ assets.operating_system?.total_vulnerabilities_count }}
             </div>
-          </template>
-        </div>
+            <div class="col-12 text-body2">
+              {{ $t('report.vulnerabilityCategory.vulnerabilities') }}
+            </div>
+          </div>
+          <div class="row q-pa-none q-pt-md">
+            <template v-for="level in vulnerabilityLevels" :key="level">
+              <div class="vulnerability-count col" :class="level.toLocaleLowerCase()">
+                {{ assets.operating_system?.[level] }}
+              </div>
+            </template>
+          </div>
+        </q-card-section>
       </q-card-section>
-    </q-card-section>
-  </q-card>
+    </q-card>
+    <h5 class="q-ma-none q-my-sm text-weight-medium">Services</h5>
+    <template v-if="assets.services?.length">
+      <template v-for="service in assets.services" :key="service">
+        <q-card flat class="bg-grey-2 q-pa-sm q-my-md" style="border-radius: 1em">
+          <q-card-section horizontal class="justify-between">
+            <q-card-section class="col-6 flex column">
+              <div class="title">{{ service.name }}</div>
+              <div class="row">
+                <div class="col-6">
+                  <div class="row q-pl-lg flex-1 items-center">
+                    <div class="col-3 text-weight-medium">
+                      {{ $t('report.vulnerabilityCategory.portNumber') }}
+                    </div>
+                    <div class="col">{{ service.port }}</div>
+                  </div>
+                </div>
+                <div class="col-6">
+                  <div class="row q-pl-lg flex-1 items-center">
+                    <div class="col-3 text-weight-medium">
+                      {{ $t('report.vulnerabilityCategory.protocol') }}
+                    </div>
+                    <div class="col">{{ service.protocol }}</div>
+                  </div>
+                </div>
+                <div class="col-6">
+                  <div class="row q-pl-lg flex-1 items-center">
+                    <div class="col-3 text-weight-medium">
+                      {{ $t('report.vulnerabilityCategory.version') }}
+                    </div>
+                    <div class="col">{{ service.cpe }}</div>
+                  </div>
+                </div>
+                <div class="col-6">
+                  <div class="row q-pl-lg flex-1 items-center">
+                    <div class="col-3 text-weight-medium">
+                      {{ $t('report.vulnerabilityCategory.detectedBanner') }}
+                    </div>
+                    <div class="col">{{ service.product }}</div>
+                  </div>
+                </div>
+              </div>
+            </q-card-section>
+            <q-separator vertical />
+            <q-card-section class="col-6 position-relative">
+              <q-btn
+                square
+                size="md"
+                flat
+                dense
+                icon="exit_to_app"
+                class="exit-button"
+                @click="goVulnerabilityTypeList"
+              ></q-btn>
+              <div class="title">{{ $t('report.vulnerabilityCategory.details') }}</div>
+              <div class="row text-center full-width">
+                <div class="col-12 text-weight-bold text-body1">
+                  {{ service.total_vulnerabilities_count }}
+                </div>
+                <div class="col-12 text-body2">
+                  {{ $t('report.vulnerabilityCategory.vulnerabilities') }}
+                </div>
+              </div>
+              <div class="row q-pa-none q-pt-md">
+                <template v-for="level in vulnerabilityLevels" :key="level">
+                  <div class="vulnerability-count col" :class="level.toLocaleLowerCase()">
+                    {{ service[level] }}
+                  </div>
+                </template>
+              </div>
+            </q-card-section>
+          </q-card-section>
+        </q-card>
+      </template>
+    </template>
+    <template v-else>
+      <p>No services found</p>
+    </template>
+  </div>
 </template>
 
 <script setup lang="ts">
-  import { computed, type ComputedRef } from 'vue';
-  import {
-    type ReportVulnerabilityGroupCategoryTypes,
-    type ReportVulnerabilityGroupItem,
-    ReportSummarySeverity,
-    ReportVulnerabilityGroupCategory
-  } from 'vulnerability/models/reports';
   import { useRouter, useRoute } from 'vue-router';
   import { VULNERABILITY_ROUTES } from 'vulnerability/routes/route-names';
+  import { CountReport, type ScanAssetResponse } from 'vulnerability/models/scans';
 
-  const props = defineProps<{
-    category: ReportVulnerabilityGroupCategoryTypes;
-    vulnerabilityGroup: ReportVulnerabilityGroupItem;
+  defineProps<{
+    assets: ScanAssetResponse;
   }>();
 
   const router = useRouter();
   const route = useRoute();
   const vulnerabilityLevels = [
-    ReportSummarySeverity.LOW,
-    ReportSummarySeverity.MEDIUM,
-    ReportSummarySeverity.HIGH,
-    ReportSummarySeverity.CRITICAL
+    CountReport.lowCount,
+    CountReport.mediumCount,
+    CountReport.highCount,
+    CountReport.criticalCount
   ];
-
-  const totalCountVulnerabilities: ComputedRef<number> = computed(() =>
-    vulnerabilityLevels.reduce((sum, level) => sum + (props.vulnerabilityGroup[level] || 0), 0)
-  );
 
   async function goVulnerabilityTypeList(): Promise<void> {
     await router.push({
       name: VULNERABILITY_ROUTES.reportsDetail.name,
-      params: { id: route.params.id, type: props.category, name: props.vulnerabilityGroup.name }
+      params: { id: route.params.id }
     });
   }
 </script>
@@ -134,19 +160,19 @@
 
   .vulnerability-count {
     text-align: center;
-    &.low {
+    &.low_count {
       background-color: #97b951;
     }
 
-    &.medium {
+    &.medium_count {
       background-color: #f6be63;
     }
 
-    &.high {
+    &.high_count {
       background-color: #f3a488;
     }
 
-    &.critical {
+    &.critical_count {
       background-color: #ed273d;
     }
   }

--- a/src/modules/vulnerability/components/drawer/MainDrawer.vue
+++ b/src/modules/vulnerability/components/drawer/MainDrawer.vue
@@ -75,19 +75,19 @@
       },
       {
         name: VULNERABILITY_ROUTES.hosts.name,
-        path: 'hosts',
+        path: '/hosts',
         icon: 'fas fa-sitemap',
         label: 'Host Details'
       },
       {
         name: VULNERABILITY_ROUTES.scans.name,
-        path: 'scans',
+        path: '/scans',
         icon: 'search',
         label: 'Scans'
       },
       {
         name: VULNERABILITY_ROUTES.reports.name,
-        path: 'reports',
+        path: '/reports',
         icon: 'warning',
         label: 'Reports'
       }

--- a/src/modules/vulnerability/models/scans.ts
+++ b/src/modules/vulnerability/models/scans.ts
@@ -206,3 +206,53 @@ export interface VendorComment {
   comment: string;
   last_modified: string;
 }
+
+export enum CountReport {
+  lowCount = 'low_count',
+  mediumCount = 'medium_count',
+  highCount = 'high_count',
+  criticalCount = 'critical_count'
+}
+
+export interface ScanAssetOperationSystem {
+  accuracy: number;
+  cpe: string;
+  family: string;
+  host_id: string;
+  id: number;
+  name: string;
+  none_count: number;
+  os_type: string;
+  scan_id: string;
+  total_vulnerabilities_count: number;
+  version: string;
+  unknown_count: number;
+  [CountReport.lowCount]: number;
+  [CountReport.mediumCount]: number;
+  [CountReport.highCount]: number;
+  [CountReport.criticalCount]: number;
+}
+
+export interface ScanAssetService {
+  cpe: string;
+  host_id: string;
+  id: number;
+  name: string;
+  none_count: number;
+  port: number;
+  port_state: string;
+  product: string;
+  protocol: string;
+  scan_id: string;
+  total_vulnerabilities_count: number;
+  unknown_count: number;
+  low_count: number;
+  medium_count: number;
+  high_count: number;
+  critical_count: number;
+}
+
+export interface ScanAssetResponse {
+  operating_system: ScanAssetOperationSystem;
+  services: ScanAssetService[];
+}

--- a/src/modules/vulnerability/pages/ReportServicePage.vue
+++ b/src/modules/vulnerability/pages/ReportServicePage.vue
@@ -1,4 +1,13 @@
 <template>
+  <Teleport :to="HEADER_ID" v-if="isMounted">
+    <q-btn
+      :label="`DOMAIN: ${vulnerabilities.alias}`"
+      size="lg"
+      flat
+      icon="arrow_back"
+      @click="$router.push({ name: VULNERABILITY_ROUTES.reports.name })"
+    ></q-btn>
+  </Teleport>
   <div class="cards-container q-pa-md">
     <div class="report-service-container">
       <report-service-card :assets="reportAssets" />
@@ -10,21 +19,30 @@
   import ReportServiceCard from 'vulnerability/components/card/ReportServiceCard.vue';
   import { useRoute } from 'vue-router';
   import { useReports } from 'vulnerability/stores/reports';
-  import type { ComputedRef } from 'vue';
-  import { computed, onMounted } from 'vue';
-  import type { ScanAssetResponse } from 'vulnerability/models/scans';
+  import type { ComputedRef, Ref } from 'vue';
+  import { computed, onMounted, ref } from 'vue';
+  import type { ScanAssetResponse, ScanVulnerabilitesResponse } from 'vulnerability/models/scans';
   import { useQuasar } from 'quasar';
+  import { HEADER_ID } from 'src/constants/idHtmlReference.constants';
+  import { VULNERABILITY_ROUTES } from '../routes/route-names';
+  import { ReportService } from '../services/report';
 
+  const vulnerabilities: Ref<ScanVulnerabilitesResponse> = ref({} as ScanVulnerabilitesResponse);
   const reportStore = useReports();
   const route = useRoute();
   const $q = useQuasar();
+  const isMounted = ref(false);
 
   const reportAssets: ComputedRef<ScanAssetResponse> = computed(
     () => reportStore.getCurrentReportAssets
   );
 
   onMounted(async () => {
+    isMounted.value = true;
     $q.loading.show();
+    vulnerabilities.value = (
+      await ReportService.getReportsVulnerabilities(String(route.params.id))
+    ).data;
     await reportStore.setCurrentReport(String(route.params.id));
     $q.loading.hide();
   });

--- a/src/modules/vulnerability/pages/ReportServicePage.vue
+++ b/src/modules/vulnerability/pages/ReportServicePage.vue
@@ -1,14 +1,7 @@
 <template>
   <div class="cards-container q-pa-md">
     <div class="report-service-container">
-      <template
-        v-for="(groupCategoryData, categoryName) in vulnerabilities"
-        :key="groupCategoryData"
-      >
-        <template v-for="categoryData in groupCategoryData" :key="categoryData">
-          <report-service-card :category="categoryName" :vulnerability-group="categoryData" />
-        </template>
-      </template>
+      <report-service-card :assets="reportAssets" />
     </div>
   </div>
 </template>
@@ -17,15 +10,23 @@
   import ReportServiceCard from 'vulnerability/components/card/ReportServiceCard.vue';
   import { useRoute } from 'vue-router';
   import { useReports } from 'vulnerability/stores/reports';
+  import type { ComputedRef } from 'vue';
   import { computed, onMounted } from 'vue';
+  import type { ScanAssetResponse } from 'vulnerability/models/scans';
+  import { useQuasar } from 'quasar';
 
   const reportStore = useReports();
   const route = useRoute();
+  const $q = useQuasar();
 
-  const vulnerabilities = computed(() => reportStore.getCurrentReportVulnerabilitiesGroupByType);
+  const reportAssets: ComputedRef<ScanAssetResponse> = computed(
+    () => reportStore.getCurrentReportAssets
+  );
 
   onMounted(async () => {
+    $q.loading.show();
     await reportStore.setCurrentReport(String(route.params.id));
+    $q.loading.hide();
   });
 </script>
 

--- a/src/modules/vulnerability/routes/routes.ts
+++ b/src/modules/vulnerability/routes/routes.ts
@@ -48,8 +48,7 @@ const routes: RouteRecordRaw[] = [
         meta: {
           title: 'Reports Service'
         },
-        // component: () => import('src/modules/vulnerability/pages/ReportServicePage.vue'),
-        redirect: { name: VULNERABILITY_ROUTES.reportsDetail.name }
+        component: () => import('src/modules/vulnerability/pages/ReportServicePage.vue')
       },
       {
         path: VULNERABILITY_ROUTES.reportsDetail.path,

--- a/src/modules/vulnerability/services/scan.ts
+++ b/src/modules/vulnerability/services/scan.ts
@@ -1,6 +1,12 @@
 import type { AxiosResponse } from 'axios';
 import { fusionAuthApi } from 'boot/axios';
-import type { Scan, ScanInsight, ScanScoreTrend, CreateScanBody } from 'vulnerability/models/scans';
+import type {
+  Scan,
+  ScanInsight,
+  ScanScoreTrend,
+  CreateScanBody,
+  ScanAssetResponse
+} from 'vulnerability/models/scans';
 
 export class ScanService {
   private static readonly BASE_PATH = '/api/scans';
@@ -44,5 +50,9 @@ export class ScanService {
     url = `${url}?${params.toString()}`;
 
     return await fusionAuthApi.get(url.toString());
+  }
+
+  static async getScanAssets(scanId: string): Promise<AxiosResponse<ScanAssetResponse>> {
+    return await fusionAuthApi.get(`${this.BASE_PATH}/${scanId}/assets`);
   }
 }

--- a/src/modules/vulnerability/stores/reports.ts
+++ b/src/modules/vulnerability/stores/reports.ts
@@ -1,29 +1,24 @@
 import { defineStore } from 'pinia';
-import type { ScanVulnerability } from 'vulnerability/models/scans';
-import { ReportService } from 'vulnerability/services/report';
-import {
-  ReportVulnerabilityGroupCategory,
-  type ReportVulnerabilityGroup
-} from 'vulnerability/models/reports';
-import { getSeverityLevel, setInitialVulnerabilityGroupItem } from 'vulnerability/helpers/reports';
+import type { ScanAssetResponse } from 'vulnerability/models/scans';
+import { ScanService } from 'vulnerability/services/scan';
+import { errorQuasarNotify } from 'src/utils';
 
 export const useReports = defineStore('reports', {
   state: () => ({
     currentReportId: '',
-    currentReportVulnerabilities: [] as ScanVulnerability[]
+    reportAssets: {} as ScanAssetResponse
   }),
 
   actions: {
     async setCurrentReport(reportId: string) {
       if (reportId !== '' && reportId !== this.currentReportId) {
         this.currentReportId = reportId;
-        this.currentReportVulnerabilities = [];
+        this.reportAssets = {} as ScanAssetResponse;
 
         try {
-          this.currentReportVulnerabilities = (
-            await ReportService.getReportsVulnerabilities(this.currentReportId)
-          ).data.vulnerabilities;
+          this.reportAssets = (await ScanService.getScanAssets(this.currentReportId)).data;
         } catch (error) {
+          errorQuasarNotify(String(error));
           console.error(error);
         }
       }
@@ -31,48 +26,8 @@ export const useReports = defineStore('reports', {
   },
 
   getters: {
-    getCurrentReportVulnerabilities(state): ScanVulnerability[] {
-      return state.currentReportVulnerabilities;
-    },
-    getCurrentReportVulnerabilitiesGroupByType(state): ReportVulnerabilityGroup {
-      const reportsByType: ReportVulnerabilityGroup = {} as ReportVulnerabilityGroup;
-
-      state.currentReportVulnerabilities.forEach(vulnerability => {
-        const severityLevel = getSeverityLevel(vulnerability.max_cvss);
-        if (vulnerability.operating_system) {
-          const osName = vulnerability.operating_system?.name || '';
-          const osData = {
-            version: vulnerability.operating_system.version,
-            precision: vulnerability.operating_system.precision
-          };
-          const osVulnerabilityReference =
-            reportsByType[ReportVulnerabilityGroupCategory.OS][osName];
-          if (!osVulnerabilityReference) {
-            reportsByType[ReportVulnerabilityGroupCategory.OS][osName] =
-              setInitialVulnerabilityGroupItem(osName, severityLevel, osData);
-          } else {
-            osVulnerabilityReference[severityLevel] += 1;
-          }
-        } else if (vulnerability.port) {
-          const portName = vulnerability.port.id || '';
-          const portData = {
-            version: vulnerability.port.version,
-            portNumber: vulnerability.port.portNumber,
-            protocol: vulnerability.port.protocol,
-            detectedBanner: vulnerability.port.detectedBanner
-          };
-          const portVulnerabilityReference =
-            reportsByType[ReportVulnerabilityGroupCategory.SERVICE][portName];
-          if (!portVulnerabilityReference) {
-            reportsByType[ReportVulnerabilityGroupCategory.SERVICE][portName] =
-              setInitialVulnerabilityGroupItem(portName, severityLevel, portData);
-          } else {
-            portVulnerabilityReference[severityLevel] += 1;
-          }
-        }
-      });
-
-      return reportsByType;
+    getCurrentReportAssets(state): ScanAssetResponse {
+      return state.reportAssets;
     }
   }
 });


### PR DESCRIPTION
<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## 🌟 What type of PR is this?
- [ ] ♻️ Refactor
- [x] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🚀 Optimization
- [ ] 📚 Documentation Update

## 📝 Description

This PR integrates the assets view, which divides the view into OS and services. The redirection to services has been implemented, but adapting the view for operating systems is still pending. It also remains to be defined whether the services view needs to be adapted for filtering by service type.

## 🔗 Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- [KT-509](https://deltateam.atlassian.net/browse/KT-509)

## 🧪 QA Instructions, Screenshots, Recordings

- After a report is generated, access its details.
- You'll see two sections for the assets.
- The OS redirection button is currently disabled, awaiting view development.
- The services button redirects to the general vulnerabilities view

## ✅ Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [ ] 👍 Yes
- [X] 🚫 No, and this is why: Pending to improve the code and clean to start the UT
- [ ] 🙋‍♀️ I need help with writing tests

<img width="1901" height="968" alt="image" src="https://github.com/user-attachments/assets/f1a4114f-7de5-4f17-b693-03d660219e57" />


[KT-509]: https://deltateam.atlassian.net/browse/KT-509?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ