### PR TITLE
feat: Add assets filter for report detail [KT-523]

### DIFF
--- a/src/modules/vulnerability/components/header/ReportDetailHeader.vue
+++ b/src/modules/vulnerability/components/header/ReportDetailHeader.vue
@@ -1,22 +1,86 @@
 <template>
   <div class="q-py-sm">
-    <q-btn
-      :label="`DOMAIN: ${vulnerabilityAlias}`"
-      size="lg"
-      flat
-      icon="arrow_back"
-      @click="$router.push({ name: VULNERABILITY_ROUTES.reports.name })"
-    ></q-btn>
+    <div class="row justify-between items-center">
+      <div class="col-6">
+        <q-btn
+          :label="`DOMAIN: ${vulnerabilityAlias}`"
+          size="lg"
+          flat
+          icon="arrow_back"
+          @click="$router.push({ name: VULNERABILITY_ROUTES.reports.name })"
+        ></q-btn>
+      </div>
+      <div class="col-2">
+        <q-select
+          outlined
+          v-model="selectedAsset"
+          :options="options"
+          label="Assets"
+          dense
+          @update:model-value="pickedAssetHandler"
+        />
+      </div>
+    </div>
   </div>
 </template>
 
 <script lang="ts" setup>
+  import type { PropType } from 'vue';
+  import { computed, ref } from 'vue';
   import { VULNERABILITY_ROUTES } from 'vulnerability/routes/route-names';
+  import type { ScanAssetResponse } from '../../models/scans';
+  import { useRouter } from 'vue-router';
 
-  defineProps({
+  const props = defineProps({
     vulnerabilityAlias: {
       type: String,
       required: true
+    },
+    assets: {
+      type: Object as PropType<ScanAssetResponse>,
+      required: true
     }
   });
+
+  const selectedAsset = ref();
+  const router = useRouter();
+
+  const options = computed(() => {
+    const auxOptions = [];
+    auxOptions.push({
+      value: props.assets.operating_system?.name,
+      label: props.assets.operating_system?.name,
+      id: props.assets.operating_system?.scan_id,
+      isOs: true
+    });
+
+    props.assets.services?.forEach(val => {
+      auxOptions.push({
+        value: val.name,
+        label: val.name,
+        id: props.assets.operating_system?.scan_id,
+        isOs: false
+      });
+    });
+    return auxOptions;
+  });
+
+  async function pickedAssetHandler(data: {
+    value: string;
+    id: string;
+    label: string;
+    isOs: boolean;
+  }): Promise<void> {
+    if (data.isOs) {
+      await router.push({
+        name: VULNERABILITY_ROUTES.reportsOsVulnerabilities.name,
+        params: { id: data.id }
+      });
+    } else {
+      await router.push({
+        name: VULNERABILITY_ROUTES.reportsDetail.name,
+        params: { id: data.id }
+      });
+    }
+  }
 </script>

--- a/src/modules/vulnerability/components/header/ReportDetailHeader.vue
+++ b/src/modules/vulnerability/components/header/ReportDetailHeader.vue
@@ -12,6 +12,7 @@
       </div>
       <div class="col-2">
         <q-select
+          v-if="options.length > 1"
           outlined
           v-model="selectedAsset"
           :options="options"
@@ -49,7 +50,7 @@
     const auxOptions = [];
     auxOptions.push({
       value: props.assets.operating_system?.name,
-      label: props.assets.operating_system?.name,
+      label: 'OS: ' + props.assets.operating_system?.name,
       id: props.assets.operating_system?.scan_id,
       isOs: true
     });
@@ -57,7 +58,7 @@
     props.assets.services?.forEach(val => {
       auxOptions.push({
         value: val.name,
-        label: val.name,
+        label: 'Service: ' + val.name,
         id: props.assets.operating_system?.scan_id,
         isOs: false
       });

--- a/src/modules/vulnerability/pages/ReportDetailPage.vue
+++ b/src/modules/vulnerability/pages/ReportDetailPage.vue
@@ -3,6 +3,8 @@
     <Teleport :to="HEADER_ID">
       <report-detail-header
         :vulnerability-alias="vulnerabilities?.alias || osVulnerabilities.alias"
+        :assets="reportAssets"
+        v-if="reportAssets"
       />
     </Teleport>
     <Teleport :to="AUX_DRAWER_ID">
@@ -56,7 +58,7 @@
   } from 'vulnerability/models/scans';
   import { ReportService } from 'vulnerability/services/report';
   import type { ComputedRef, Ref } from 'vue';
-  import { onBeforeUnmount, onMounted, ref, nextTick, computed } from 'vue';
+  import { onBeforeUnmount, onMounted, ref, nextTick, computed, watch } from 'vue';
   import { useRoute } from 'vue-router';
   import { useQuasar } from 'quasar';
   import VulnerabilityCard from 'vulnerability/components/card/VulnerabilityCard.vue';
@@ -121,7 +123,13 @@
     }
   }
 
-  onMounted(async () => {
+  watch(route, async () => {
+    await initialSetup();
+  });
+
+  async function initialSetup() {
+    vulnerabilities.value = null;
+    osVulnerabilities.value = {} as ScanOsVulnerabilityResponse;
     miscStore.updateShowSecondDrawer(true);
     if (route.name === VULNERABILITY_ROUTES.reportsOsVulnerabilities.name) {
       isOs.value = true;
@@ -161,6 +169,7 @@
         errorQuasarNotify('Error : OS vulnerabilities are not available');
       }
     } else {
+      isOs.value = false;
       $q.loading.show();
       vulnerabilities.value = (await ReportService.getReportsVulnerabilities(scanId)).data;
       $q.loading.hide();
@@ -169,6 +178,10 @@
         isMounted.value = true;
       });
     }
+  }
+
+  onMounted(async () => {
+    await initialSetup();
   });
 
   onBeforeUnmount(() => {


### PR DESCRIPTION
<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## 🌟 What type of PR is this? (check all applicable)
- [ ] ♻️ Refactor
- [x] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🚀 Optimization
- [ ] 📚 Documentation Update

## 📝 Description

This story covers the creation of a dropdown component for listing a scan’s assets. This component will be used at both the Service and Operating System asset detail view, and will help the user quickly navigate between and compare a scan’s vulnerable assets.  

## 🔗 Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- [KT-523](https://deltateam.atlassian.net/browse/KT-523)


## 🧪 QA Instructions, Screenshots, Recordings


<img width="1897" height="1079" alt="image" src="https://github.com/user-attachments/assets/79a485ba-1b19-497a-b7c7-cfca92349fa0" />

<img width="1915" height="1079" alt="image" src="https://github.com/user-attachments/assets/ddc51c29-6c24-49e2-a536-6419e57c78ea" />





[KT-523]: https://deltateam.atlassian.net/browse/KT-523?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ