### PR TITLE
feat: UI: Implement Vulnerability List for Service [KT-511]

### DIFF
--- a/src/modules/vulnerability/components/card/ReportServiceCard.vue
+++ b/src/modules/vulnerability/components/card/ReportServiceCard.vue
@@ -102,7 +102,7 @@
                 dense
                 icon="exit_to_app"
                 class="exit-button"
-                @click="goVulnerabilityTypeList"
+                @click="goVulnerabilityTypeList(service.id)"
               ></q-btn>
               <div class="title">{{ $t('report.vulnerabilityCategory.details') }}</div>
               <div class="row text-center full-width">
@@ -149,10 +149,10 @@
     CountReport.criticalCount
   ];
 
-  async function goVulnerabilityTypeList(): Promise<void> {
+  async function goVulnerabilityTypeList(serviceId: number): Promise<void> {
     await router.push({
-      name: VULNERABILITY_ROUTES.reportsDetail.name,
-      params: { id: route.params.id }
+      name: VULNERABILITY_ROUTES.reportsServiceDetail.name,
+      params: { id: route.params.id, serviceId }
     });
   }
 

--- a/src/modules/vulnerability/components/card/VulnerabilityCard.vue
+++ b/src/modules/vulnerability/components/card/VulnerabilityCard.vue
@@ -251,7 +251,7 @@
             >
               <q-card style="border-radius: 1em" :class="`border-${vulnerabilityLevel}`">
                 <q-card-section>
-                  <template v-if="vulnerability.references.length">
+                  <template v-if="vulnerability.references?.length">
                     <div v-for="reference in vulnerability.references" :key="reference">
                       <a :href="reference" target="_blank">{{ reference }}</a>
                     </div>
@@ -326,7 +326,11 @@
   import type { ComputedRef, Ref } from 'vue';
   import { computed, onMounted, ref } from 'vue';
   import type { AxiosError } from 'axios';
-  import type { ScanVulnerability, ScanVulnerabilityMetric } from 'vulnerability/models/scans';
+  import type {
+    ScanVulnerability,
+    ScanVulnerabilityMetric,
+    ScanWebVulnerabilityItem
+  } from 'vulnerability/models/scans';
   import { VULNERABILITY_ROUTES } from 'vulnerability/routes/route-names';
   import { VulnerabilitiesService } from 'vulnerability/services/vulnerabilities';
   import { errorQuasarNotify, successQuasarNotify } from 'src/utils';
@@ -339,7 +343,12 @@
   const props = defineProps({
     vulnerability: {
       type: {} as () => ScanVulnerability,
-      required: true
+      required: true,
+      default: {} as ScanVulnerability
+    },
+    webVulnerability: {
+      type: {} as () => ScanWebVulnerabilityItem,
+      required: false
     },
     showComments: {
       type: Boolean,

--- a/src/modules/vulnerability/components/card/VulnerabilityCard.vue
+++ b/src/modules/vulnerability/components/card/VulnerabilityCard.vue
@@ -67,6 +67,7 @@
               expand-separator
               label="CVSS - Common Vulnerability Scoring System"
               header-class="item-title"
+              v-if="currentMetricVersion || rows.length"
             >
               <q-card style="border-radius: 1em" :class="`border-${vulnerabilityLevel}`">
                 <q-card-section>
@@ -177,6 +178,7 @@
               expand-separator
               label="EPSS - Exploit Prediction Scoring System"
               header-class="item-title"
+              v-if="vulnerability.epss_score || vulnerability.epss_percentile"
             >
               <q-card style="border-radius: 1em" :class="`border-${vulnerabilityLevel}`">
                 <q-card-section>

--- a/src/modules/vulnerability/components/card/VulnerabilityCard.vue
+++ b/src/modules/vulnerability/components/card/VulnerabilityCard.vue
@@ -272,9 +272,9 @@
               <q-card style="border-radius: 1em" :class="`border-${vulnerabilityLevel}`">
                 <q-card-section>
                   <ul class="q-pl-md">
-                    <template v-if="vulnerability.remediation?.length">
+                    <template v-if="vulnerability.remediations?.length">
                       <li
-                        v-for="remediation in vulnerability.remediation"
+                        v-for="remediation in vulnerability.remediations"
                         :key="remediation.cwe_id"
                       >
                         <span class="text-weight-medium">{{ remediation.cwe_id }} :</span>

--- a/src/modules/vulnerability/components/card/WebVulnerabilityCard.vue
+++ b/src/modules/vulnerability/components/card/WebVulnerabilityCard.vue
@@ -1,0 +1,221 @@
+<template>
+  <q-card flat class="card-vulnerability q-pa-md" :class="`card-${vulnerabilityLevel}`">
+    <div class="row justify-end">
+      <div class="col-6 text-title flex items-center justify-between">
+        {{ webVulnerability.title }}
+        <q-btn icon="info" flat @click="goWebVulnerabilityDetail"></q-btn>
+      </div>
+      <q-separator vertical class="q-mx-md" color="black" />
+
+      <div class="col text-muted">
+        <div class="row flex justify-start">
+          <div class="col-6">
+            <div>Instances : {{ webVulnerability.instances_count }}</div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <!-- <div class="row justify-end">
+        <div class="col-6 text-title flex items-center justify-between">
+          {{ webVulnerability.vulnerability_id }}
+        </div>
+        <q-separator vertical class="q-mx-md" color="black" />
+
+        <div class="col text-muted">
+          <div class="row flex justify-end">
+            <div class="col-6">
+              <div :class="`cvss-${vulnerabilityLevel}`">
+                {{ $t('report.vulnerabilityDetail.maxCvss') }} :
+                <span class="value">{{ vulnerability.max_cvss?.toFixed(1) }}</span>
+              </div>
+              <div>
+                {{ $t('report.vulnerabilityDetail.riskScore') }} : {{ vulnerability.risk_score }}
+              </div>
+              <div>
+                {{ $t('report.vulnerabilityDetail.likelihood') }} : {{ vulnerability.likelihood }}
+              </div>
+              <div>
+                {{ $t('report.vulnerabilityDetail.impactScore') }} :
+                {{ vulnerability.impact_score }}
+              </div>
+            </div>
+            <div class="col-6">
+              <div>{{ $t('report.vulnerabilityDetail.access') }} : {{ vulnerability.access }}</div>
+              <div>
+                {{ $t('report.vulnerabilityDetail.complexity') }} : {{ vulnerability.complexity }}
+              </div>
+              <div>
+                {{ $t('report.vulnerabilityDetail.privileges') }} : {{ vulnerability.privileges }}
+              </div>
+              <div>
+                {{ $t('report.vulnerabilityDetail.exploitability') }} :
+                {{ vulnerability.exploitability }}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div> -->
+  </q-card>
+</template>
+
+<script setup lang="ts">
+  import { computed, type ComputedRef, type PropType } from 'vue';
+  import { type ScanWebVulnerabilityItem } from 'vulnerability/models/scans';
+  import { type ReportSummarySeverityTypes } from '../../models/reports';
+  import { getSeverityLevel } from '../../helpers/reports';
+  import { useRouter } from 'vue-router';
+  import { VULNERABILITY_ROUTES } from '../../routes/route-names';
+
+  const props = defineProps({
+    webVulnerability: {
+      type: Object as PropType<ScanWebVulnerabilityItem>,
+      required: true
+    }
+  });
+
+  const router = useRouter();
+
+  const vulnerabilityLevel: ComputedRef<ReportSummarySeverityTypes> = computed(() =>
+    getSeverityLevel(0)
+  );
+
+  async function goWebVulnerabilityDetail() {
+    await router.push({
+      name: VULNERABILITY_ROUTES.reportsWebDetailVul.name,
+      params: { id: props.webVulnerability.scan_id, idvul: props.webVulnerability.vulnerability_id }
+    });
+  }
+</script>
+
+<style lang="scss">
+  .card {
+    &-vulnerability {
+      background-color: #f6f7fc;
+      overflow-y: auto;
+    }
+
+    &-medium {
+      border-left: #fbbf65 10px solid;
+    }
+
+    &-critical {
+      border-left: #e5494d 10px solid;
+    }
+
+    &-low {
+      border-left: #97b951 10px solid;
+    }
+
+    &-high {
+      border-left: #f3a488 10px solid;
+    }
+  }
+
+  .cvss {
+    &-medium {
+      .value {
+        border: #fbbf65 1px solid;
+        background: #fbbf651a;
+        padding: 0 5px;
+        width: fit-content;
+        font-weight: 500;
+        color: black;
+      }
+    }
+
+    &-critical {
+      .value {
+        border: #e5494d 1px solid;
+        background: #ed273d1a;
+        padding: 0 5px;
+        width: fit-content;
+        font-weight: 500;
+        color: black;
+      }
+    }
+
+    &-low {
+      .value {
+        border: #97b951 1px solid;
+        background: #46a7581a;
+        padding: 0 5px;
+        width: fit-content;
+        font-weight: 500;
+        color: black;
+      }
+    }
+
+    &-high {
+      .value {
+        border: #f3a488 1px solid;
+        background: #fbbf651a;
+        padding: 0 5px;
+        width: fit-content;
+        font-weight: 500;
+        color: black;
+      }
+    }
+  }
+
+  .text-title {
+    color: #313541;
+    font-weight: 700;
+    font-size: 16px;
+  }
+
+  .text-muted {
+    color: #5c7288;
+    font-size: 11px;
+  }
+
+  .v-enter-active,
+  .v-leave-active {
+    transition: opacity 0.5s ease;
+  }
+
+  .v-enter-from,
+  .v-leave-to {
+    opacity: 0;
+  }
+
+  .description-scroll {
+    height: 80px;
+    overflow-y: auto;
+  }
+
+  .item-title {
+    .q-item__label {
+      font-weight: bold;
+      color: #313541;
+    }
+  }
+
+  .border-low {
+    border: #97b951 1px solid;
+  }
+
+  .border-medium {
+    border: #fbbf65 1px solid;
+  }
+
+  .border-high {
+    border: #f3a488 1px solid;
+  }
+
+  .border-critical {
+    border: #e5494d 1px solid;
+  }
+
+  .container-card {
+    border: 1px solid #313541;
+    text-align: left;
+    margin: 2px 0;
+    padding: 0.5em 1em;
+
+    .title {
+      font-size: 1em;
+      line-height: normal;
+      text-align: left;
+    }
+  }
+</style>

--- a/src/modules/vulnerability/components/card/WebVulnerabilityCard.vue
+++ b/src/modules/vulnerability/components/card/WebVulnerabilityCard.vue
@@ -3,7 +3,7 @@
     <div class="row justify-end">
       <div class="col-6 text-title flex items-center justify-between">
         {{ webVulnerability.title }}
-        <q-btn icon="info" flat @click="goWebVulnerabilityDetail"></q-btn>
+        <q-btn icon="info" flat @click="showDetail = !showDetail"></q-btn>
       </div>
       <q-separator vertical class="q-mx-md" color="black" />
 
@@ -15,51 +15,32 @@
         </div>
       </div>
     </div>
-    <!-- <div class="row justify-end">
-        <div class="col-6 text-title flex items-center justify-between">
-          {{ webVulnerability.vulnerability_id }}
-        </div>
-        <q-separator vertical class="q-mx-md" color="black" />
+  </q-card>
 
-        <div class="col text-muted">
-          <div class="row flex justify-end">
-            <div class="col-6">
-              <div :class="`cvss-${vulnerabilityLevel}`">
-                {{ $t('report.vulnerabilityDetail.maxCvss') }} :
-                <span class="value">{{ vulnerability.max_cvss?.toFixed(1) }}</span>
-              </div>
-              <div>
-                {{ $t('report.vulnerabilityDetail.riskScore') }} : {{ vulnerability.risk_score }}
-              </div>
-              <div>
-                {{ $t('report.vulnerabilityDetail.likelihood') }} : {{ vulnerability.likelihood }}
-              </div>
-              <div>
-                {{ $t('report.vulnerabilityDetail.impactScore') }} :
-                {{ vulnerability.impact_score }}
-              </div>
-            </div>
-            <div class="col-6">
-              <div>{{ $t('report.vulnerabilityDetail.access') }} : {{ vulnerability.access }}</div>
-              <div>
-                {{ $t('report.vulnerabilityDetail.complexity') }} : {{ vulnerability.complexity }}
-              </div>
-              <div>
-                {{ $t('report.vulnerabilityDetail.privileges') }} : {{ vulnerability.privileges }}
-              </div>
-              <div>
-                {{ $t('report.vulnerabilityDetail.exploitability') }} :
-                {{ vulnerability.exploitability }}
-              </div>
-            </div>
-          </div>
-        </div>
-      </div> -->
+  <q-card v-if="showDetail">
+    <q-card-section>
+      <ul class="q-pl-md">
+        <h6 class="q-my-none">Remediation</h6>
+        <template v-if="webVulnerability.remediations?.length">
+          <li v-for="remediation in webVulnerability.remediations" :key="remediation.cwe_id">
+            <span class="text-weight-medium">{{ remediation.cwe_id }} :</span>
+            {{ remediation.description }}
+          </li>
+        </template>
+        <template v-else>
+          {{ 'No data available' }}
+        </template>
+      </ul>
+    </q-card-section>
+
+    <q-card-actions align="right">
+      <q-btn label="Report" color="primary" @click="goWebVulnerabilityDetail"></q-btn>
+    </q-card-actions>
   </q-card>
 </template>
 
 <script setup lang="ts">
-  import { computed, type ComputedRef, type PropType } from 'vue';
+  import { computed, ref, type ComputedRef, type PropType } from 'vue';
   import { type ScanWebVulnerabilityItem } from 'vulnerability/models/scans';
   import { type ReportSummarySeverityTypes } from '../../models/reports';
   import { getSeverityLevel } from '../../helpers/reports';
@@ -74,6 +55,7 @@
   });
 
   const router = useRouter();
+  const showDetail = ref(false);
 
   const vulnerabilityLevel: ComputedRef<ReportSummarySeverityTypes> = computed(() =>
     getSeverityLevel(0)

--- a/src/modules/vulnerability/components/header/ReportDetailHeader.vue
+++ b/src/modules/vulnerability/components/header/ReportDetailHeader.vue
@@ -64,7 +64,8 @@
       auxOptions.push({
         value: val.name,
         label: 'Service: ' + val.name,
-        id: props.assets.operating_system?.scan_id,
+        scanId: val.scan_id,
+        id: val.id,
         isOs: false
       });
     });
@@ -76,6 +77,7 @@
     id: string;
     label: string;
     isOs: boolean;
+    scanId: string;
   }): Promise<void> {
     if (data.isOs) {
       await router.push({
@@ -84,8 +86,8 @@
       });
     } else {
       await router.push({
-        name: VULNERABILITY_ROUTES.reportsDetail.name,
-        params: { id: data.id }
+        name: VULNERABILITY_ROUTES.reportsServiceDetail.name,
+        params: { id: data.scanId, serviceId: data.id }
       });
     }
   }

--- a/src/modules/vulnerability/components/header/ReportDetailHeader.vue
+++ b/src/modules/vulnerability/components/header/ReportDetailHeader.vue
@@ -3,7 +3,7 @@
     <div class="row justify-between items-center">
       <div class="col-6">
         <q-btn
-          :label="`DOMAIN: ${vulnerabilityAlias}`"
+          :label="`${isDomain ? 'DOMAIN' : 'SERVICE'}: ${vulnerabilityAlias} ${port != 0 ? 'PORT:' + port : ''}`"
           size="lg"
           flat
           icon="arrow_back"
@@ -45,6 +45,15 @@
     assets: {
       type: Object as PropType<ScanAssetResponse>,
       required: true
+    },
+    isDomain: {
+      type: Boolean,
+      default: false
+    },
+    port: {
+      type: Number,
+      require: false,
+      default: 0
     }
   });
 

--- a/src/modules/vulnerability/components/header/ReportDetailVulnerabilityHeader.vue
+++ b/src/modules/vulnerability/components/header/ReportDetailVulnerabilityHeader.vue
@@ -1,22 +1,16 @@
 <template>
   <div class="q-py-sm">
     <q-btn
-      :label="`DOMAIN: ${domainName}`"
+      :label="`${isDomain ? 'DOMAIN' : 'SERVICE'}: ${domainName}`"
       size="lg"
       flat
       icon="arrow_back"
-      @click="
-        $router.push({
-          name: VULNERABILITY_ROUTES.reportsDetail.name,
-          params: { id: reportId }
-        })
-      "
+      @click="$router.go(-1)"
     ></q-btn>
   </div>
 </template>
 
 <script lang="ts" setup>
-  import { VULNERABILITY_ROUTES } from 'vulnerability/routes/route-names';
   defineProps({
     domainName: {
       type: String,
@@ -25,6 +19,10 @@
     reportId: {
       type: String,
       default: ''
+    },
+    isDomain: {
+      type: Boolean,
+      default: false
     }
   });
 </script>

--- a/src/modules/vulnerability/models/scans.ts
+++ b/src/modules/vulnerability/models/scans.ts
@@ -189,6 +189,7 @@ export interface ScanWebVulnerabilityItem {
   severity: string;
   title: string;
   vulnerability_id: string;
+  remediations?: VulnerabilityRemediation[];
 }
 
 export interface ScanWebVulnerability {
@@ -203,6 +204,7 @@ export interface ScanWebVulnerability {
   updated_at: string;
   vulnerability_id: string;
   wasc_id: string;
+  remediations?: VulnerabilityRemediation[];
 }
 
 export interface ScanWebVulnerabilityInstance {

--- a/src/modules/vulnerability/models/scans.ts
+++ b/src/modules/vulnerability/models/scans.ts
@@ -134,7 +134,7 @@ export interface ScanVulnerability {
   vendor_comments?: VendorComment[];
   references: string[];
   description?: string;
-  remediation?: VulnerabilityRemediation[];
+  remediations?: VulnerabilityRemediation[];
   metrics?: ScanVulnerabilityMetric[];
   port?: {
     id: string;

--- a/src/modules/vulnerability/models/scans.ts
+++ b/src/modules/vulnerability/models/scans.ts
@@ -91,6 +91,7 @@ export interface ScanVulnerabilitesResponse {
   total_vulnerabilities: number;
   severity_counts: ScanVulnerabilitesServerityCounts;
   vulnerabilities: ScanVulnerability[];
+  service_port: number;
 }
 
 export interface ScanVulnerabilitesServerityCounts {

--- a/src/modules/vulnerability/models/scans.ts
+++ b/src/modules/vulnerability/models/scans.ts
@@ -91,6 +91,7 @@ export interface ScanVulnerabilitesResponse {
   total_vulnerabilities: number;
   severity_counts: ScanVulnerabilitesServerityCounts;
   vulnerabilities: ScanVulnerability[];
+  web_vulnerabilities: ScanWebVulnerabilityItem[];
   service_port: number;
 }
 
@@ -178,6 +179,39 @@ export interface ScanVulnerability {
   };
   epss_percentile: number;
   epss_score: number;
+}
+
+export interface ScanWebVulnerabilityItem {
+  host_id: string;
+  instances_count: number;
+  scan_id: string;
+  service_id: string;
+  severity: string;
+  title: string;
+  vulnerability_id: string;
+}
+
+export interface ScanWebVulnerability {
+  created_at: string;
+  cwe_id: string;
+  host_id: string;
+  instances: ScanWebVulnerabilityInstance[];
+  reference: string;
+  scan_id: string;
+  service_id: string;
+  solution_advice: string;
+  updated_at: string;
+  vulnerability_id: string;
+  wasc_id: string;
+}
+
+export interface ScanWebVulnerabilityInstance {
+  attack: string;
+  evidence: string;
+  method: string;
+  other_info: string;
+  param: string;
+  uri: string;
 }
 
 export interface ScanOsVulnerabilityResponse {

--- a/src/modules/vulnerability/models/scans.ts
+++ b/src/modules/vulnerability/models/scans.ts
@@ -87,6 +87,7 @@ export interface ScanTableEventAction {
 export interface ScanVulnerabilitesResponse {
   scan_date: string;
   alias: string;
+  service_name: string;
   total_vulnerabilities: number;
   severity_counts: ScanVulnerabilitesServerityCounts;
   vulnerabilities: ScanVulnerability[];

--- a/src/modules/vulnerability/pages/ReportDetailPage.vue
+++ b/src/modules/vulnerability/pages/ReportDetailPage.vue
@@ -63,7 +63,7 @@
           </div>
         </template>
         <template v-else>
-          <p>No vulnerabilities found</p>
+          <p>No vulnerabilities found for this service</p>
         </template>
       </div>
     </div>

--- a/src/modules/vulnerability/pages/ReportDetailPage.vue
+++ b/src/modules/vulnerability/pages/ReportDetailPage.vue
@@ -6,6 +6,8 @@
           vulnerabilities?.alias || osVulnerabilities.alias || vulnerabilities?.service_name || ''
         "
         :assets="reportAssets"
+        :is-domain="isOs"
+        :port="vulnerabilities?.service_port || 0"
         v-if="reportAssets"
       />
     </Teleport>
@@ -172,15 +174,21 @@
       }
     } else {
       isOs.value = false;
-      $q.loading.show();
-      vulnerabilities.value = (
-        await ReportService.getReportsServiceVulnerabilities(
-          scanId,
-          route.params.serviceId as string
-        )
-      ).data;
-      $q.loading.hide();
-      sortList('Vulnerability');
+      try {
+        $q.loading.show();
+        vulnerabilities.value = (
+          await ReportService.getReportsServiceVulnerabilities(
+            scanId,
+            route.params.serviceId as string
+          )
+        ).data;
+        $q.loading.hide();
+        sortList('Vulnerability');
+      } catch (err) {
+        console.error(err);
+        errorQuasarNotify('Error : Service vulnerabilities are not available');
+      }
+
       await nextTick(() => {
         isMounted.value = true;
       });

--- a/src/modules/vulnerability/pages/ReportDetailPage.vue
+++ b/src/modules/vulnerability/pages/ReportDetailPage.vue
@@ -53,13 +53,18 @@
         </div>
 
         <h6 class="q-ma-none text-weight-bold q-my-md">Web Vulnerabilities</h6>
-        <div
-          v-for="vul in vulnerabilities?.web_vulnerabilities"
-          :key="vul.vulnerability_id"
-          class="col-12"
-        >
-          <web-vulnerability-card :web-vulnerability="vul" />
-        </div>
+        <template v-if="vulnerabilities?.web_vulnerabilities.length">
+          <div
+            v-for="vul in vulnerabilities?.web_vulnerabilities"
+            :key="vul.vulnerability_id"
+            class="col-12"
+          >
+            <web-vulnerability-card :web-vulnerability="vul" />
+          </div>
+        </template>
+        <template v-else>
+          <p>No vulnerabilities found</p>
+        </template>
       </div>
     </div>
   </template>

--- a/src/modules/vulnerability/pages/ReportDetailPage.vue
+++ b/src/modules/vulnerability/pages/ReportDetailPage.vue
@@ -46,8 +46,20 @@
         :options="['Vulnerability', 'Cvss', 'Risk']"
         @update:model-value="sortList"
       ></q-select>
-      <div v-for="vul in vulnerabilities?.vulnerabilities" :key="vul.id" class="col-12">
-        <vulnerability-card :vulnerability="vul" @comment-updated="handleCommentUpdated" />
+      <div class="col-12">
+        <h6 class="q-ma-none text-weight-bold q-my-md">Vulnerabilities</h6>
+        <div v-for="vul in vulnerabilities?.vulnerabilities" :key="vul.id" class="col-12">
+          <vulnerability-card :vulnerability="vul" @comment-updated="handleCommentUpdated" />
+        </div>
+
+        <h6 class="q-ma-none text-weight-bold q-my-md">Web Vulnerabilities</h6>
+        <div
+          v-for="vul in vulnerabilities?.web_vulnerabilities"
+          :key="vul.vulnerability_id"
+          class="col-12"
+        >
+          <web-vulnerability-card :web-vulnerability="vul" />
+        </div>
       </div>
     </div>
   </template>
@@ -61,6 +73,7 @@
     ScanVulnerability
   } from 'vulnerability/models/scans';
   import { ReportService } from 'vulnerability/services/report';
+  import WebVulnerabilityCard from '../components/card/WebVulnerabilityCard.vue';
   import type { ComputedRef, Ref } from 'vue';
   import { onBeforeUnmount, onMounted, ref, nextTick, computed, watch } from 'vue';
   import { useRoute } from 'vue-router';

--- a/src/modules/vulnerability/pages/ReportDetailPage.vue
+++ b/src/modules/vulnerability/pages/ReportDetailPage.vue
@@ -2,7 +2,9 @@
   <template v-if="isMounted">
     <Teleport :to="HEADER_ID">
       <report-detail-header
-        :vulnerability-alias="vulnerabilities?.alias || osVulnerabilities.alias"
+        :vulnerability-alias="
+          vulnerabilities?.alias || osVulnerabilities.alias || vulnerabilities?.service_name || ''
+        "
         :assets="reportAssets"
         v-if="reportAssets"
       />
@@ -171,7 +173,12 @@
     } else {
       isOs.value = false;
       $q.loading.show();
-      vulnerabilities.value = (await ReportService.getReportsVulnerabilities(scanId)).data;
+      vulnerabilities.value = (
+        await ReportService.getReportsServiceVulnerabilities(
+          scanId,
+          route.params.serviceId as string
+        )
+      ).data;
       $q.loading.hide();
       sortList('Vulnerability');
       await nextTick(() => {

--- a/src/modules/vulnerability/pages/ReportDetailVulnerability.vue
+++ b/src/modules/vulnerability/pages/ReportDetailVulnerability.vue
@@ -1,28 +1,105 @@
 <template>
-  <template v-if="isMounted">
-    <Teleport :to="HEADER_ID">
-      <report-detail-vulnerability-header
-        :domain-name="vulnerability.host?.alias || ''"
-        :report-id="reportId"
+  <div class="q-pa-md">
+    <template v-if="isMounted">
+      <Teleport :to="HEADER_ID">
+        <report-detail-vulnerability-header
+          :domain-name="vulnerability.host?.alias || webVulnerability.cwe_id || ''"
+          :report-id="reportId"
+          :is-domain="!isWebVulnerability"
+        />
+      </Teleport>
+      <Teleport :to="AUX_DRAWER_ID" v-if="!isWebVulnerability">
+        <report-detail-vulnerability-drawer :vulnerability="vulnerability" />
+      </Teleport>
+    </template>
+
+    <template v-if="isWebVulnerability">
+      <q-card>
+        <q-card-section>
+          <div class="row justify-end">
+            <div class="col-4 text-title flex items-center justify-between">
+              {{ webVulnerability.cwe_id }}
+            </div>
+            <q-separator vertical class="q-mx-md" color="black" />
+
+            <div class="col text-muted">
+              <div class="row flex justify-end">
+                <div class="col">
+                  <div>
+                    <span class="text-weight-bold"> Reference: </span>
+                    <span>
+                      {{ webVulnerability.reference }}
+                    </span>
+                  </div>
+                  <div>
+                    <span class="text-weight-bold"> Solution Advice: </span>
+                    <span>
+                      {{ webVulnerability.solution_advice }}
+                    </span>
+                  </div>
+                  <div>
+                    <span class="text-weight-bold"> WASC ID: </span>
+                    <span>
+                      {{ webVulnerability.wasc_id }}
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </q-card-section>
+      </q-card>
+
+      <q-card class="q-mt-md">
+        <q-card-section class="text-weight-bold"> Instances </q-card-section>
+        <div style="max-height: 75vh; overflow-y: auto">
+          <template v-for="instance in webVulnerability.instances" :key="instance.uri">
+            <q-card-section>
+              <div class="row">
+                <div class="col-4 text-title">URI:</div>
+                <div class="col">{{ instance.uri }}</div>
+              </div>
+              <div class="row">
+                <div class="col-4 text-title">Attack:</div>
+                <div class="col">{{ instance.attack }}</div>
+              </div>
+              <div class="row">
+                <div class="col-4 text-title">Method:</div>
+                <div class="col">{{ instance.method }}</div>
+              </div>
+              <div class="row">
+                <div class="col-4 text-title">Param:</div>
+                <div class="col">{{ instance.param }}</div>
+              </div>
+              <div class="row">
+                <div class="col-4 text-title">Evidence:</div>
+                <div class="col">{{ instance.evidence }}</div>
+              </div>
+              <div class="row">
+                <div class="col-4 text-title">Other Info:</div>
+                <div class="col">{{ instance.other_info }}</div>
+              </div>
+            </q-card-section>
+          </template>
+        </div>
+      </q-card>
+    </template>
+    <template v-else>
+      <vulnerability-card
+        :vulnerability="vulnerability"
+        :detail-view="false"
+        :show-comments="false"
+        @comment-updated="handleCommentUpdated"
       />
-    </Teleport>
-    <Teleport :to="AUX_DRAWER_ID">
-      <report-detail-vulnerability-drawer :vulnerability="vulnerability" />
-    </Teleport>
-  </template>
-  <vulnerability-card
-    :vulnerability="vulnerability"
-    :detail-view="false"
-    :show-comments="false"
-    @comment-updated="handleCommentUpdated"
-  />
+    </template>
+  </div>
 </template>
 
 <script setup lang="ts">
-  import type { ScanVulnerability } from 'vulnerability/models/scans';
+  import type { ScanVulnerability, ScanWebVulnerability } from 'vulnerability/models/scans';
   import { VulnerabilitiesService } from 'vulnerability/services/vulnerabilities';
   import type { Ref } from 'vue';
-  import { onMounted, onUnmounted, ref } from 'vue';
+  import { computed, onMounted, onUnmounted, ref } from 'vue';
   import { useRoute } from 'vue-router';
   import VulnerabilityCard from 'vulnerability/components/card/VulnerabilityCard.vue';
   import { useMiscStore } from 'vulnerability/stores/misc';
@@ -30,6 +107,7 @@
   import ReportDetailVulnerabilityDrawer from 'vulnerability/components/drawer/ReportDetailVulnerabilityDrawer.vue';
   import { HEADER_ID, AUX_DRAWER_ID } from 'src/constants/idHtmlReference.constants';
   import { errorQuasarNotify } from 'src/utils';
+  import { VULNERABILITY_ROUTES } from '../routes/route-names';
 
   const route = useRoute();
   const id = route.params.idvul as string;
@@ -37,6 +115,7 @@
   const vulnerability: Ref<ScanVulnerability> = ref({} as ScanVulnerability);
   const isMounted = ref(false);
   const miscStore = useMiscStore();
+  const webVulnerability: Ref<ScanWebVulnerability> = ref({} as ScanWebVulnerability);
 
   function handleCommentUpdated(payload: { newComment: string }) {
     const vulnerabilityToUpdate = vulnerability.value;
@@ -48,15 +127,28 @@
     }
   }
 
-  onMounted(async () => {
-    miscStore.updateShowSecondDrawer(true);
-    try {
-      vulnerability.value = (await VulnerabilitiesService.getVulnerabilitesById(id)).data;
-    } catch (err) {
-      errorQuasarNotify(`Unable to get vulnerability`);
-      console.error(err);
-    }
+  const isWebVulnerability = computed(
+    () => route.name == VULNERABILITY_ROUTES.reportsWebDetailVul.name
+  );
 
+  onMounted(async () => {
+    if (isWebVulnerability.value) {
+      try {
+        webVulnerability.value = (await VulnerabilitiesService.getWebVulnerabilityById(id)).data;
+      } catch (err) {
+        errorQuasarNotify(`Unable to get vulnerability`);
+        console.error(err);
+      }
+    } else {
+      miscStore.updateShowSecondDrawer(true);
+
+      try {
+        vulnerability.value = (await VulnerabilitiesService.getVulnerabilitesById(id)).data;
+      } catch (err) {
+        errorQuasarNotify(`Unable to get vulnerability`);
+        console.error(err);
+      }
+    }
     isMounted.value = true;
   });
 

--- a/src/modules/vulnerability/pages/ReportDetailVulnerability.vue
+++ b/src/modules/vulnerability/pages/ReportDetailVulnerability.vue
@@ -49,39 +49,70 @@
           </div>
         </q-card-section>
       </q-card>
+      <q-card class="q-mt-md" style="max-height: 75vh; overflow-y: auto">
+        <q-list bordered class="rounded-borders">
+          <q-expansion-item
+            expand-separator
+            label="Instances"
+            header-class="item-title"
+            group="webvul"
+          >
+            <q-card>
+              <q-card-section>
+                <template v-for="instance in webVulnerability.instances" :key="instance.uri">
+                  <q-card-section>
+                    <div class="row">
+                      <div class="col-4 text-title">URI:</div>
+                      <div class="col">{{ instance.uri }}</div>
+                    </div>
+                    <div class="row">
+                      <div class="col-4 text-title">Attack:</div>
+                      <div class="col">{{ instance.attack }}</div>
+                    </div>
+                    <div class="row">
+                      <div class="col-4 text-title">Method:</div>
+                      <div class="col">{{ instance.method }}</div>
+                    </div>
+                    <div class="row">
+                      <div class="col-4 text-title">Param:</div>
+                      <div class="col">{{ instance.param }}</div>
+                    </div>
+                    <div class="row">
+                      <div class="col-4 text-title">Evidence:</div>
+                      <div class="col">{{ instance.evidence }}</div>
+                    </div>
+                    <div class="row">
+                      <div class="col-4 text-title">Other Info:</div>
+                      <div class="col">{{ instance.other_info }}</div>
+                    </div>
+                  </q-card-section>
+                </template>
+              </q-card-section>
+            </q-card>
+          </q-expansion-item>
+          <q-expansion-item
+            expand-separator
+            label="Remediation"
+            header-class="item-title"
+            group="webvul"
+          >
+            <q-card>
+              <q-card-section>
+                <template v-if="webVulnerability.remediations?.length">
+                  <li
+                    v-for="remediation in webVulnerability.remediations"
+                    :key="remediation.cwe_id"
+                  >
+                    <span class="text-weight-medium">{{ remediation.cwe_id }} :</span>
+                    {{ remediation.description }}
+                  </li>
+                </template>
 
-      <q-card class="q-mt-md">
-        <q-card-section class="text-weight-bold"> Instances </q-card-section>
-        <div style="max-height: 75vh; overflow-y: auto">
-          <template v-for="instance in webVulnerability.instances" :key="instance.uri">
-            <q-card-section>
-              <div class="row">
-                <div class="col-4 text-title">URI:</div>
-                <div class="col">{{ instance.uri }}</div>
-              </div>
-              <div class="row">
-                <div class="col-4 text-title">Attack:</div>
-                <div class="col">{{ instance.attack }}</div>
-              </div>
-              <div class="row">
-                <div class="col-4 text-title">Method:</div>
-                <div class="col">{{ instance.method }}</div>
-              </div>
-              <div class="row">
-                <div class="col-4 text-title">Param:</div>
-                <div class="col">{{ instance.param }}</div>
-              </div>
-              <div class="row">
-                <div class="col-4 text-title">Evidence:</div>
-                <div class="col">{{ instance.evidence }}</div>
-              </div>
-              <div class="row">
-                <div class="col-4 text-title">Other Info:</div>
-                <div class="col">{{ instance.other_info }}</div>
-              </div>
-            </q-card-section>
-          </template>
-        </div>
+                <template v-else> No data available </template>
+              </q-card-section>
+            </q-card>
+          </q-expansion-item>
+        </q-list>
       </q-card>
     </template>
     <template v-else>

--- a/src/modules/vulnerability/routes/route-names.ts
+++ b/src/modules/vulnerability/routes/route-names.ts
@@ -34,5 +34,9 @@ export const VULNERABILITY_ROUTES = {
   reportsDetailVul: {
     name: 'ReportsDetailVul',
     path: 'reports/:id/vulnerability/:idvul'
+  },
+  reportsWebDetailVul: {
+    name: 'ReportsDetailVul',
+    path: 'reports/:id/web-vulnerability/:idvul'
   }
 };

--- a/src/modules/vulnerability/routes/route-names.ts
+++ b/src/modules/vulnerability/routes/route-names.ts
@@ -19,6 +19,10 @@ export const VULNERABILITY_ROUTES = {
     name: 'ReportsDetail',
     path: 'reports/:id'
   },
+  reportsServiceDetail: {
+    name: 'ReportsServiceDetail',
+    path: 'reports/:id/services/:serviceId'
+  },
   reportsOsVulnerabilities: {
     name: 'ReportsOsVulnerabilities',
     path: 'reports/:id/operating-system/vulnerabilities'

--- a/src/modules/vulnerability/routes/route-names.ts
+++ b/src/modules/vulnerability/routes/route-names.ts
@@ -36,7 +36,7 @@ export const VULNERABILITY_ROUTES = {
     path: 'reports/:id/vulnerability/:idvul'
   },
   reportsWebDetailVul: {
-    name: 'ReportsDetailVul',
+    name: 'ReportsDetailWebVul',
     path: 'reports/:id/web-vulnerability/:idvul'
   }
 };

--- a/src/modules/vulnerability/routes/routes.ts
+++ b/src/modules/vulnerability/routes/routes.ts
@@ -67,6 +67,14 @@ const routes: RouteRecordRaw[] = [
         component: () => import('src/modules/vulnerability/pages/ReportDetailPage.vue')
       },
       {
+        path: VULNERABILITY_ROUTES.reportsServiceDetail.path,
+        name: VULNERABILITY_ROUTES.reportsServiceDetail.name,
+        meta: {
+          title: 'Reports'
+        },
+        component: () => import('src/modules/vulnerability/pages/ReportDetailPage.vue')
+      },
+      {
         path: VULNERABILITY_ROUTES.reportsDetailVul.path,
         name: VULNERABILITY_ROUTES.reportsDetailVul.name,
         meta: {

--- a/src/modules/vulnerability/routes/routes.ts
+++ b/src/modules/vulnerability/routes/routes.ts
@@ -81,6 +81,14 @@ const routes: RouteRecordRaw[] = [
           title: 'Reports'
         },
         component: () => import('src/modules/vulnerability/pages/ReportDetailVulnerability.vue')
+      },
+      {
+        path: VULNERABILITY_ROUTES.reportsWebDetailVul.path,
+        name: VULNERABILITY_ROUTES.reportsWebDetailVul.name,
+        meta: {
+          title: 'Reports'
+        },
+        component: () => import('src/modules/vulnerability/pages/ReportDetailVulnerability.vue')
       }
     ]
   }

--- a/src/modules/vulnerability/services/report.ts
+++ b/src/modules/vulnerability/services/report.ts
@@ -22,6 +22,15 @@ export class ReportService {
     return await fusionAuthApi.get(`${this.BASE_PATH_SCANS}/${scanId}/vulnerabilities`);
   }
 
+  static async getReportsServiceVulnerabilities(
+    scanId: string,
+    serviceId: string
+  ): Promise<AxiosResponse<ScanVulnerabilitesResponse>> {
+    return await fusionAuthApi.get(
+      `${this.BASE_PATH_SCANS}/${scanId}/services/${serviceId}/vulnerabilities`
+    );
+  }
+
   static async getReportsVulnerabilitiesSummary(
     scanId: string,
     severity: string,

--- a/src/modules/vulnerability/services/vulnerabilities.ts
+++ b/src/modules/vulnerability/services/vulnerabilities.ts
@@ -1,12 +1,17 @@
 import type { AxiosResponse } from 'axios';
 import { fusionAuthApi } from 'boot/axios';
-import type { ScanVulnerability } from 'vulnerability/models/scans';
+import type { ScanVulnerability, ScanWebVulnerability } from 'vulnerability/models/scans';
 
 export class VulnerabilitiesService {
   private static readonly BASE_PATH = '/api/vulnerabilities';
+  private static readonly BASE_PATH_WEB = '/api/web-vulnerabilities';
 
   static async getVulnerabilitesById(id: string): Promise<AxiosResponse<ScanVulnerability>> {
     return await fusionAuthApi.get(`${this.BASE_PATH}/${id}`);
+  }
+
+  static async getWebVulnerabilityById(id: string): Promise<AxiosResponse<ScanWebVulnerability>> {
+    return await fusionAuthApi.get(`${this.BASE_PATH_WEB}/${id}`);
   }
 
   static async postVulnerabilityComment(id: string, comment: string): Promise<AxiosResponse> {


### PR DESCRIPTION
<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## 🌟 What type of PR is this? (check all applicable)
- [ ] ♻️ Refactor
- [x] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🚀 Optimization
- [ ] 📚 Documentation Update

## 📝 Description

This story covers the implementation of the “drill-down” view that a user sees after clicking on a specific Service asset (e.g., “Apache HTTP Server”) from the main scan results page. This view will display a consolidated list of all vulnerabilities found for said service.
This view will also include a navigation dropdown allowing the user to quickly switch to viewing vulnerabilities for other assets (the OS or other services) from the same scan.

## 🔗 Related Tickets & Documents

https://deltateam.atlassian.net/browse/KT-511

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->


## ✅ Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [ ] 👍 Yes
- [x] 🚫 No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] 🙋‍♀️ I need help with writing tests
