### PR TITLE
feat: Fix Reports WebSockets [KT-499]

### DIFF
--- a/src/modules/vulnerability/pages/ReportPage.vue
+++ b/src/modules/vulnerability/pages/ReportPage.vue
@@ -491,6 +491,8 @@
         }
       ]
     };
+    // Navigate to the dynamic vector step
+    reportPageStep.value = 1;
   }
 
   function onDragStartEventHandler(index, val) {


### PR DESCRIPTION
<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## 🌟 What type of PR is this? (check all applicable)
- [ ] ♻️ Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 🚀 Optimization
- [ ] 📚 Documentation Update

## 📝 Description

This PR fixes websocket functionality to use database-driven OWASP Top 10 categories instead of runtime mapping. Frontend-wise, this means just re-enabling the reports page and testing it with https://github.com/kptm-tools/core-service/pull/180

## 🔗 Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue [KT-499](https://deltateam.atlassian.net/browse/KT-499?atlOrigin=eyJpIjoiOGM4OTBmYTU0YWNhNGVkNWJkZjE1ZDhjYmM5YjZlYzQiLCJwIjoiaiJ9)

## 🧪 QA Instructions, Screenshots, Recordings

https://www.loom.com/share/9c71a52ab6eb4b0b966a5cf955679825

## ✅ Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [ ] 👍 Yes
- [x] 🚫 No, and this is why: Just a one-liner to re-enable reports
- [ ] 🙋‍♀️ I need help with writing tests


[KT-499]: https://deltateam.atlassian.net/browse/KT-499?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ