### PR TITLE
fix: os vulnerability remediations are not rendering [VUL-6]

### DIFF
--- a/src/modules/vulnerability/components/card/VulnerabilityCard.vue
+++ b/src/modules/vulnerability/components/card/VulnerabilityCard.vue
@@ -271,20 +271,26 @@
             >
               <q-card style="border-radius: 1em" :class="`border-${vulnerabilityLevel}`">
                 <q-card-section>
-                  <ul class="q-pl-md">
-                    <template v-if="vulnerability.remediations?.length">
+                  <template v-if="vulnerability.remediations?.length">
+                    <ul class="q-pl-md">
                       <li
-                        v-for="remediation in vulnerability.remediations"
-                        :key="remediation.cwe_id"
+                        v-for="(remediation, index) in vulnerability.remediations"
+                        :key="`${remediation.cwe_id}-${index}`"
                       >
-                        <span class="text-weight-medium">{{ remediation.cwe_id }} :</span>
-                        {{ remediation.description }}
+                        <div v-if="remediation.cwe_id || remediation.title">
+                          <span class="text-weight-medium">{{ remediation.cwe_id || remediation.title }}:</span>
+                        </div>
+                        <div>{{ remediation.description }}</div>
+                        <div v-if="remediation.effectiveness" class="text-caption text-grey-7 q-mt-xs">
+                          Effectiveness: {{ remediation.effectiveness }}
+                          <span v-if="remediation.effectiveness_notes"> - {{ remediation.effectiveness_notes }}</span>
+                        </div>
                       </li>
-                    </template>
-                    <template v-else>
-                      {{ 'No data available' }}
-                    </template>
-                  </ul>
+                    </ul>
+                  </template>
+                  <template v-else>
+                    <div class="text-grey-7">No remediation information available</div>
+                  </template>
                 </q-card-section>
               </q-card>
             </q-expansion-item>

--- a/src/modules/vulnerability/models/scans.ts
+++ b/src/modules/vulnerability/models/scans.ts
@@ -222,12 +222,12 @@ export interface ScanOsVulnerabilityResponse {
   os_name: string;
   os_type: string;
   references: string[];
-  remediation: VulnerabilityRemediation[];
   scan_date: string;
   scan_id: string;
   severity_counts: SeverityCounts;
   total_vulnerabilities: number;
   vulnerabilities: ScanOsVulnerability[];
+  remediations?: VulnerabilityRemediation[];
 }
 
 export interface ScanOsVulnerability {
@@ -247,6 +247,8 @@ export interface ScanOsVulnerability {
   severity: string;
   type: string;
   vendor_comments: VendorComment[];
+  remediations: VulnerabilityRemediation[];
+
 }
 
 export interface ScanScoreTrend {

--- a/src/modules/vulnerability/pages/ReportDetailPage.vue
+++ b/src/modules/vulnerability/pages/ReportDetailPage.vue
@@ -205,6 +205,7 @@
             name: data.name,
             privileges: data.privileges,
             references: data.references,
+            remediations: data.remediations,
             risk_score: data.risk_score,
             severity: data.severity,
             type: data.type,


### PR DESCRIPTION
## 🌟 What type of PR is this? (check all applicable)
- [ ] ♻️ Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 🚀 Optimization
- [ ] 📚 Documentation Update

## 📝 Description

This is a quick bug fix that focuses on an error where remediations for an Operating System's NetworkOS vulnerabilities were never displayed. This was because the models were not up to date with the API docs.

It also improves the styling slightly for this `<q-card-section/>` element 😄 

## 🔗 Related Tickets & Documents

- Closes # [VUL-6](https://linear.app/kptm-audits/issue/VUL-6/os-vulnerability-remediations-are-not-rendering)

## 🧪 QA Instructions, Screenshots, Recordings

<img width="1904" height="844" alt="image" src="https://github.com/user-attachments/assets/32ba8a69-1723-4522-ba50-58d37a6e1288" />
