### PR TITLE
fix: Update scan table column Duration -> Duration [VUL-7]

### DIFF
--- a/src/constants/table.constants.ts
+++ b/src/constants/table.constants.ts
@@ -140,10 +140,10 @@ export const SCAN_TABLE_COLUMNS: QTableColumn[] = [
     field: 'severity'
   },
   {
-    name: 'Durations',
-    label: 'Durations',
+    name: 'Duration',
+    label: 'Duration',
     align: 'left',
-    field: 'durations'
+    field: 'duration'
   },
   {
     name: 'Status',

--- a/src/modules/vulnerability/components/table/TableScan.vue
+++ b/src/modules/vulnerability/components/table/TableScan.vue
@@ -17,7 +17,7 @@
         <severity-chip :severity="column.value" />
       </template>
 
-      <template v-else-if="column.field === 'durations'">
+      <template v-else-if="column.field === 'duration'">
         {{ formatDuration(column.value) }}
       </template>
 

--- a/src/modules/vulnerability/models/scans.ts
+++ b/src/modules/vulnerability/models/scans.ts
@@ -19,7 +19,7 @@ export interface ScanTableColums {
   host: string;
   numVulnerabilities: number;
   severity: SeverityCounts;
-  durations: string;
+  duration: string;
   status: string;
 }
 

--- a/src/utils/__test__/scan.utils.vitest.spec.ts
+++ b/src/utils/__test__/scan.utils.vitest.spec.ts
@@ -42,7 +42,7 @@ describe('formatScansForTable', () => {
         host: 'localhost',
         numVulnerabilities: 5,
         severity: { critical: 2, high: 3, medium: 0, low: 0 },
-        durations: 120,
+        duration: 120,
         status: ScanStatus.completed
       },
       {
@@ -51,7 +51,7 @@ describe('formatScansForTable', () => {
         host: 'example.com',
         numVulnerabilities: 10,
         severity: { critical: 1, high: 4, medium: 3, low: 2 },
-        durations: 300,
+        duration: 300,
         status: ScanStatus.inProgress
       }
     ];
@@ -85,11 +85,11 @@ describe('formatDuration', () => {
     expect(formatDuration(0)).toBe('0s');
   });
 
-  it('should handle durations less than a minute correctly', () => {
+  it('should handle duration less than a minute correctly', () => {
     expect(formatDuration(59)).toBe('59s');
   });
 
-  it('should handle durations less than an hour correctly', () => {
+  it('should handle duration less than an hour correctly', () => {
     expect(formatDuration(3599)).toBe('59m 59s');
   });
 });

--- a/src/utils/scan.utils.ts
+++ b/src/utils/scan.utils.ts
@@ -17,7 +17,7 @@ export function formatScansForTable(scans: Scan[]): Record<string, unknown>[] {
     host: scan.host,
     numVulnerabilities: scan.vulnerabilities,
     severity: scan.severities,
-    durations: scan.duration,
+    duration: scan.duration,
     status: scan.status
   }));
 }
@@ -92,10 +92,10 @@ export const SCAN_TABLE_COLUMNS: QTableColumn[] = [
     field: 'severity'
   },
   {
-    name: 'Durations',
-    label: 'Durations',
+    name: 'Duration',
+    label: 'Duration',
     align: 'left',
-    field: 'durations'
+    field: 'duration'
   },
   {
     name: 'Status',


### PR DESCRIPTION
<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## 🌟 What type of PR is this? (check all applicable)
- [ ] ♻️ Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🚀 Optimization
- [ ] 📚 Documentation Update

## 📝 Description

## 🔗 Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes # [VUL-7](https://linear.app/kptm-audits/issue/VUL-7/scan-table-column-says-durations-instead-of-duration)

## 🧪 QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, a note
on the devices and browsers this has been tested on, as well as any relevant
images for UI changes._

## ✅ Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [ ] 👍 Yes
- [ ] 🚫 No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] 🙋‍♀️ I need help with writing tests
