### PR TITLE
fix: Add none and unknown count to ReportServiceCard and CountReport model [VUL-13]

### DIFF
--- a/src/modules/vulnerability/components/card/ReportServiceCard.vue
+++ b/src/modules/vulnerability/components/card/ReportServiceCard.vue
@@ -143,6 +143,8 @@
   const router = useRouter();
   const route = useRoute();
   const vulnerabilityLevels = [
+    CountReport.noneCount,
+    CountReport.unknownCount,
     CountReport.lowCount,
     CountReport.mediumCount,
     CountReport.highCount,
@@ -175,6 +177,12 @@
 
   .vulnerability-count {
     text-align: center;
+    &.none_count {
+      background-color: #D3D3D3;
+    }
+    &.unknown_count {
+      background-color: #A9A9A9;
+    }
     &.low_count {
       background-color: #97b951;
     }
@@ -184,7 +192,7 @@
     }
 
     &.high_count {
-      background-color: #f3a488;
+      background-color: #FF8C00;
     }
 
     &.critical_count {

--- a/src/modules/vulnerability/models/scans.ts
+++ b/src/modules/vulnerability/models/scans.ts
@@ -275,6 +275,8 @@ export interface VendorComment {
 }
 
 export enum CountReport {
+  noneCount = 'none_count',
+  unknownCount = 'unknown_count',
   lowCount = 'low_count',
   mediumCount = 'medium_count',
   highCount = 'high_count',
@@ -294,6 +296,8 @@ export interface ScanAssetOperationSystem {
   total_vulnerabilities_count: number;
   version: string;
   unknown_count: number;
+  [CountReport.noneCount]: number;
+  [CountReport.unknownCount]: number;
   [CountReport.lowCount]: number;
   [CountReport.mediumCount]: number;
   [CountReport.highCount]: number;


### PR DESCRIPTION
…

## 🌟 What type of PR is this? (check all applicable)
- [ ] ♻️ Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 🚀 Optimization
- [ ] 📚 Documentation Update

## 📝 Description

This PR adds missing "None" and "Unknown" counts to asset bars, ensuring that total severities are now aggregated by the individual counts.

## 🔗 Related Tickets & Documents

- Closes # [VUL-13](https://linear.app/kptm-audits/issue/VUL-13/no-asset-colored-bars-for-none-and-unknown-vulnerabilities)

## 🧪 QA Instructions, Screenshots, Recordings

<img width="1904" height="839" alt="image" src="https://github.com/user-attachments/assets/e9d8c171-1adc-4d6c-a98f-2caefcfa15b8" />

