### PR TITLE
feat: modernize DialogreportInsight with cybersecurity-focused & OWASP chart [VUL-20]

### DIFF
--- a/src/modules/vulnerability/components/dialog/DialogReportInsight.vue
+++ b/src/modules/vulnerability/components/dialog/DialogReportInsight.vue
@@ -1,61 +1,89 @@
 <template>
   <q-dialog ref="dialogRef" class="dialog-scan-insight" @hide="onDialogHide">
     <q-card class="q-dialog-plugin full-width">
-      <q-card-section class="q-mb-md row q-col-gutter-sm">
-        <div class="title q-mb-md col-6">Domain : {{ insight.domain }}</div>
-        <div class="col-3">
-          <q-select
-            v-model="severityPicked"
-            outlined
-            multiple
-            dense
-            :options="severityOptions"
-            label="Severity"
-            @update:model-value="handlerSelect"
-          />
-        </div>
-        <div class="col-3">
-          <q-select
-            v-model="timePicked"
-            outlined
-            dense
-            :options="timeOptions"
-            label="Time Range"
-            @update:model-value="handlerSelect"
-          />
+      <q-card-section class="q-pb-none">
+        <div class="row items-center q-col-gutter-md q-mb-lg">
+          <div class="col-6">
+            <div class="dialog-header">
+              <h5 class="dialog-title">{{ insight.domain }}</h5>
+              <div class="dialog-subtitle">Vulnerability Analysis Report</div>
+            </div>
+          </div>
+          <div class="col-3">
+            <q-select
+              v-model="severityPicked"
+              outlined
+              multiple
+              dense
+              :options="severityOptions"
+              label="Severity Filter"
+              @update:model-value="handlerSelect"
+            />
+          </div>
+          <div class="col-3">
+            <q-select
+              v-model="timePicked"
+              outlined
+              dense
+              :options="timeOptions"
+              label="Time Range"
+              @update:model-value="handlerSelect"
+            />
+          </div>
         </div>
       </q-card-section>
-      <q-card-section>
-        <div class="row q-col-gutter-lg">
-          <div class="col-6">
-            <div class="row q-mb-md">
-              <div class="title">General Summary of Vulnerabilities</div>
-
-              <div class="full-width">
+      <q-card-section class="q-pt-none">
+        <div class="row q-col-gutter-xl q-mb-xl">
+          <div class="col-12 col-md-5">
+            <div class="chart-section">
+              <div class="chart-header">
+                <h6 class="chart-title">Vulnerability Distribution by Severity</h6>
+                <div class="chart-subtitle">Risk level breakdown</div>
+              </div>
+              <div class="chart-container">
                 <apexchart
-                  :options="SCAN_INSIGHT_VULNERABILITY_OPTIONS"
+                  :options="modernDonutOptions"
                   :series="generalSummaryValues"
+                  :height="380"
                 ></apexchart>
               </div>
             </div>
           </div>
-          <div v-if="showGraph" class="col-6">
-            <div class="title">Vulnerabilities by Category</div>
-            <apexchart
-              :options="vulnerabiltyOptions"
-              :series="vulnerabilitiesValues"
-              :height="400"
-            ></apexchart>
+          <div v-if="showGraph" class="col-12 col-md-7">
+            <div class="chart-section owasp-chart-section">
+              <div class="chart-header">
+                <h6 class="chart-title">OWASP Top 10 2021 Categories</h6>
+                <div class="chart-subtitle">Vulnerability distribution by category</div>
+              </div>
+              <div class="chart-container">
+                <apexchart
+                  :options="owaspCategoryOptions"
+                  :series="vulnerabilitiesValues"
+                  :height="380"
+                ></apexchart>
+              </div>
+            </div>
           </div>
         </div>
-        <div class="row justify-center">
-          <apexchart
-            type="line"
-            height="300"
-            :options="vulnerabilityTrendOptions"
-            :series="vulnerabilitiesTrendValues"
-            width="700"
-          ></apexchart>
+        <div class="row q-mt-xl">
+          <div class="col-12">
+            <div class="chart-section">
+              <div class="chart-header q-mb-md">
+                <h6 class="chart-title">Vulnerability Trends Over Time</h6>
+                <div class="chart-subtitle">
+                  Shows the latest scan data for each time period and the overall average
+                </div>
+              </div>
+              <div class="chart-container">
+                <apexchart
+                  type="line"
+                  height="340"
+                  :options="vulnerabilityTrendOptions"
+                  :series="vulnerabilitiesTrendValues"
+                ></apexchart>
+              </div>
+            </div>
+          </div>
         </div>
       </q-card-section> </q-card
   ></q-dialog>
@@ -65,7 +93,7 @@
   import { useDialogPluginComponent } from 'quasar';
   import type { PropType } from 'vue';
   import { computed, onMounted, ref } from 'vue';
-  import { SCAN_INSIGHT_VULNERABILITY_OPTIONS } from 'src/constants/apexcharts.constants';
+  import { SCAN_INSIGHT_VULNERABILITY_OPTIONS, APP_CHART_THEME } from 'src/constants/apexcharts.constants';
   import type { ReportSummary } from 'vulnerability/models/reports';
   import { ReportSummarySeverity, ReportSummaryTimeRange } from 'vulnerability/models/reports';
   import { ReportService } from 'vulnerability/services/report';
@@ -83,6 +111,120 @@
   const showGraph = ref(true);
 
   const { dialogRef, onDialogHide } = useDialogPluginComponent();
+  
+  // Enhanced donut chart options with cybersecurity-appropriate colors
+  const modernDonutOptions = computed(() => {
+    const cybersecurityColors = [
+      '#DC2626', // Critical - Red
+      '#F97316', // High - Orange  
+      '#EAB308', // Medium - Yellow/Amber
+      '#16A34A', // Low - Green
+      '#06B6D4', // None - Cyan
+      '#8B5CF6'  // Unknown - Purple
+    ];
+
+    return {
+      ...SCAN_INSIGHT_VULNERABILITY_OPTIONS,
+      chart: {
+        ...SCAN_INSIGHT_VULNERABILITY_OPTIONS.chart,
+        height: 380,
+        width: '100%',
+        background: 'transparent'
+      },
+      colors: cybersecurityColors,
+      plotOptions: {
+        pie: {
+          donut: {
+            size: '65%',
+            labels: {
+              show: true,
+              name: {
+                show: true,
+                fontSize: '16px',
+                fontFamily: APP_CHART_THEME.fontFamily,
+                fontWeight: 600,
+                color: APP_CHART_THEME.colors.primary,
+                offsetY: -8
+              },
+              value: {
+                show: true,
+                fontSize: '28px',
+                fontFamily: APP_CHART_THEME.fontFamily,
+                fontWeight: 800,
+                color: APP_CHART_THEME.colors.primary,
+                offsetY: 8,
+                formatter: function (value: string) {
+                  return value;
+                }
+              },
+              total: {
+                show: true,
+                showAlways: true,
+                label: 'Total Vulnerabilities',
+                fontSize: '14px',
+                fontFamily: APP_CHART_THEME.fontFamily,
+                fontWeight: 600,
+                color: APP_CHART_THEME.colors.secondary,
+                formatter: function (w: { globals: { seriesTotals: number[] } }) {
+                  const total = w.globals.seriesTotals.reduce((a: number, b: number) => a + b, 0);
+                  return total.toString();
+                }
+              }
+            }
+          }
+        }
+      },
+      legend: {
+        show: true,
+        position: 'bottom',
+        horizontalAlign: 'center',
+        fontSize: '14px',
+        fontFamily: APP_CHART_THEME.fontFamily,
+        fontWeight: '500',
+        offsetY: 10,
+        labels: {
+          colors: APP_CHART_THEME.colors.primary,
+          useSeriesColors: false
+        },
+        markers: {
+          width: 14,
+          height: 14,
+          radius: 3
+        },
+        itemMargin: {
+          horizontal: 12,
+          vertical: 8
+        }
+      },
+      tooltip: {
+        theme: 'light',
+        style: {
+          fontSize: '13px',
+          fontFamily: APP_CHART_THEME.fontFamily
+        },
+        y: {
+          formatter: function(value: number, { seriesIndex }: { seriesIndex: number }) {
+            const severityNames = ['Critical', 'High', 'Medium', 'Low', 'None', 'Unknown'];
+            const severityName = severityNames[seriesIndex] || 'Unknown';
+            return `${value} ${severityName.toLowerCase()} severity vulnerabilities`;
+          }
+        }
+      },
+      dataLabels: {
+        enabled: true,
+        style: {
+          fontSize: '12px',
+          fontFamily: APP_CHART_THEME.fontFamily,
+          fontWeight: '600',
+          colors: ['#ffffff']
+        },
+        dropShadow: {
+          enabled: false
+        }
+      }
+    };
+  });
+
   const generalSummaryValues = computed(() =>
     Object.values(insightInformation.value.general_summary.severity_counts)
   );
@@ -101,23 +243,123 @@
   const severityPicked = ref([]);
   const timePicked = ref('' as ReportSummaryTimeRange);
 
-  const vulnerabiltyOptions = computed(() => {
+  // Modern OWASP Top 10 2021 category chart options
+  const owaspCategoryOptions = computed(() => {
     const categories = insightInformation.value.vulnerabilities_by_category.category_data.map(
       category => category.category
     );
+    
+    // Cybersecurity gradient colors for OWASP categories
+    const owaspColors = [
+      '#DC2626', '#EF4444', '#F97316', '#FB923C', 
+      '#EAB308', '#FACC15', '#16A34A', '#22C55E',
+      '#06B6D4', '#22D3EE', '#8B5CF6', '#A78BFA'
+    ];
+
     return {
       chart: {
-        height: 'auto',
-        type: 'radar',
+        height: 380,
+        type: 'bar',
+        fontFamily: APP_CHART_THEME.fontFamily,
+        background: 'transparent',
         toolbar: {
+          show: false
+        },
+        animations: {
+          enabled: true,
+          easing: 'easeinout',
+          speed: 800
+        }
+      },
+      colors: owaspColors,
+      plotOptions: {
+        bar: {
+          horizontal: true,
+          borderRadius: 6,
+          dataLabels: {
+            position: 'top'
+          },
+          barHeight: '75%'
+        }
+      },
+      dataLabels: {
+        enabled: true,
+        offsetX: 30,
+        style: {
+          fontSize: '12px',
+          fontFamily: APP_CHART_THEME.fontFamily,
+          fontWeight: '600',
+          colors: [APP_CHART_THEME.colors.primary]
+        }
+      },
+      xaxis: {
+        categories: categories,
+        labels: {
+          style: {
+            fontSize: '12px',
+            fontFamily: APP_CHART_THEME.fontFamily,
+            colors: APP_CHART_THEME.colors.secondary
+          }
+        },
+        axisBorder: {
+          show: false
+        },
+        axisTicks: {
           show: false
         }
       },
       yaxis: {
-        stepSize: 20
+        labels: {
+          style: {
+            fontSize: '11px',
+            fontFamily: APP_CHART_THEME.fontFamily,
+            colors: APP_CHART_THEME.colors.secondary
+          },
+          maxWidth: 180,
+          formatter: function(value: string) {
+            // Truncate long OWASP category names
+            if (value.length > 25) {
+              return value.substring(0, 22) + '...';
+            }
+            return value;
+          }
+        }
       },
-      xaxis: {
-        categories: categories
+      grid: {
+        show: true,
+        borderColor: '#f1f5f9',
+        strokeDashArray: 2,
+        xaxis: {
+          lines: {
+            show: true
+          }
+        },
+        yaxis: {
+          lines: {
+            show: false
+          }
+        }
+      },
+      tooltip: {
+        theme: 'light',
+        style: {
+          fontSize: '12px',
+          fontFamily: APP_CHART_THEME.fontFamily
+        },
+        x: {
+          show: true,
+          formatter: function(value: string) {
+            return value; // Show full category name in tooltip
+          }
+        },
+        y: {
+          formatter: function(value: number) {
+            return `${value} vulnerabilities`;
+          }
+        }
+      },
+      legend: {
+        show: false
       }
     };
   });
@@ -125,37 +367,136 @@
   const vulnerabilityTrendOptions = computed(() => {
     return {
       chart: {
-        height: 350,
-        type: 'line'
+        height: 340,
+        type: 'line',
+        fontFamily: APP_CHART_THEME.fontFamily,
+        background: 'transparent',
+        toolbar: {
+          show: false
+        },
+        zoom: {
+          enabled: false
+        }
       },
+      colors: ['#DC2626', '#16A34A'], // Red for Latest Scan, Green for Average
       stroke: {
-        curve: 'smooth'
+        curve: 'smooth',
+        width: [3, 2],
+        dashArray: [0, 5]
       },
       fill: {
         type: 'solid',
-        opacity: [0.35, 1]
+        opacity: [0.35, 0.15]
       },
       dataLabels: {
-        enabled: true,
-        enabledOnSeries: [0]
+        enabled: false
       },
-      labels: insightInformation.value.vulnerability_trends.time_periods.map(
-        period => period.time_period
-      ),
       markers: {
-        size: 0
+        size: [4, 0],
+        colors: ['#DC2626', '#16A34A'],
+        strokeColors: '#fff',
+        strokeWidth: 2,
+        hover: {
+          size: 6
+        }
       },
-      yaxis: [
-        {
-          title: {
-            text: 'Vulnerabilites'
+      grid: {
+        show: true,
+        borderColor: '#f1f5f9',
+        strokeDashArray: 2,
+        xaxis: {
+          lines: {
+            show: false
+          }
+        },
+        yaxis: {
+          lines: {
+            show: true
           }
         }
-      ],
-      xasis: {
+      },
+      xaxis: {
+        type: 'category',
+        categories: insightInformation.value.vulnerability_trends.time_periods.map(
+          period => period.time_period
+        ),
         labels: {
           show: true,
-          rotate: 90
+          rotate: -45,
+          maxHeight: 80,
+          style: {
+            fontSize: '12px',
+            fontFamily: APP_CHART_THEME.fontFamily,
+            colors: APP_CHART_THEME.colors.secondary
+          }
+        },
+        axisBorder: {
+          show: false
+        },
+        axisTicks: {
+          show: false
+        }
+      },
+      yaxis: {
+        title: {
+          text: 'Number of Vulnerabilities',
+          style: {
+            fontSize: '12px',
+            fontFamily: APP_CHART_THEME.fontFamily,
+            fontWeight: 500,
+            color: APP_CHART_THEME.colors.secondary
+          }
+        },
+        labels: {
+          style: {
+            fontSize: '12px',
+            fontFamily: APP_CHART_THEME.fontFamily,
+            colors: APP_CHART_THEME.colors.secondary
+          }
+        }
+      },
+      legend: {
+        show: true,
+        position: 'top',
+        horizontalAlign: 'center',
+        fontSize: '13px',
+        fontFamily: APP_CHART_THEME.fontFamily,
+        fontWeight: '500',
+        labels: {
+          colors: APP_CHART_THEME.colors.secondary
+        },
+        markers: {
+          width: 12,
+          height: 12,
+          radius: 3
+        }
+      },
+      tooltip: {
+        theme: 'light',
+        style: {
+          fontSize: '12px',
+          fontFamily: APP_CHART_THEME.fontFamily
+        },
+        x: {
+          show: true
+        },
+        y: {
+          title: {
+            formatter: (seriesName: string) => {
+              if (seriesName === 'Count') {
+                return 'Latest Scan: ';
+              } else if (seriesName === 'Average') {
+                return 'Period Average: ';
+              }
+              return seriesName + ': ';
+            }
+          },
+          formatter: (value: number | null) => {
+            if (value === null) {
+              return 'No scan data available';
+            }
+            return Math.round(value).toString() + ' vulnerabilities';
+          }
         }
       }
     };
@@ -172,17 +513,17 @@
 
   const vulnerabilitiesTrendValues = computed(() => [
     {
-      name: 'Count',
+      name: 'Latest Scan per Period',
       type: 'line',
       data: insightInformation.value.vulnerability_trends.time_periods.map(period =>
-        period.vulnerability_count == null ? null : period.vulnerability_count.toFixed(2)
+        period.vulnerability_count == null ? null : Math.round(period.vulnerability_count)
       )
     },
     {
-      name: 'Average',
+      name: 'Overall Average',
       type: 'line',
       data: insightInformation.value.vulnerability_trends.time_periods.map(() =>
-        insightInformation.value.vulnerability_trends.average_vulnerability_count.toFixed(2)
+        Math.round(insightInformation.value.vulnerability_trends.average_vulnerability_count)
       )
     }
   ]);
@@ -207,12 +548,81 @@
     color: #313541;
 
     .q-dialog-plugin {
-      max-width: 750px;
-      width: 100%;
-      overflow: hidden;
-      height: 750px;
+      max-width: 1400px;
+      width: 95vw;
+      max-height: 90vh;
+      overflow-y: auto;
+      border-radius: 12px;
     }
 
+    // Header styles
+    .dialog-header {
+      .dialog-title {
+        font-size: 24px;
+        font-weight: 800;
+        line-height: 1.2;
+        color: #1a1a1a;
+        margin: 0;
+        padding: 0;
+      }
+
+      .dialog-subtitle {
+        font-size: 14px;
+        font-weight: 500;
+        color: #6b7280;
+        margin-top: 4px;
+      }
+    }
+
+    // Chart section styles
+    .chart-section {
+      background: #ffffff;
+      border-radius: 12px;
+      border: 1px solid #f1f5f9;
+      padding: 24px;
+      height: 100%;
+      
+      &:hover {
+        border-color: #e2e8f0;
+        box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.05);
+        transition: all 0.2s ease-in-out;
+      }
+    }
+
+    .chart-header {
+      margin-bottom: 20px;
+      
+      .chart-title {
+        font-size: 18px;
+        font-weight: 700;
+        line-height: 1.3;
+        color: #1a1a1a;
+        margin: 0 0 4px 0;
+      }
+
+      .chart-subtitle {
+        font-size: 13px;
+        font-weight: 500;
+        color: #6b7280;
+        line-height: 1.4;
+      }
+    }
+
+    .chart-container {
+      position: relative;
+      width: 100%;
+      overflow: visible;
+    }
+
+    // Specific styles for OWASP chart to handle long category names
+    .owasp-chart-section {
+      .chart-container {
+        padding-left: 10px;
+        margin-left: -10px;
+      }
+    }
+
+    // Legacy title class for backward compatibility
     .title {
       font-size: 16px;
       font-weight: 700;


### PR DESCRIPTION


## 🌟 What type of PR is this? (check all applicable)
- [x] ♻️ Refactor
- [x] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🚀 Optimization
- [ ] 📚 Documentation Update

## 📝 Description

- Enhanced donut chart with cybersecurity color scheme
- Replaced radar chart with horizontal bar chart for OWASP categories
- Improved dialog layout with card-based sections
- Better spacing, typography and responsive design

## 🔗 Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue # [VUL-19](https://linear.app/kptm-audits/issue/VUL-19/vulnerabilities-by-category-are-not-being-fetched-properly)
- Closes # [VUL-20](https://linear.app/kptm-audits/issue/VUL-20/ui-enhance-report-summary-dialog)

## 🧪 QA Instructions, Screenshots, Recordings

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/962a20f9-350f-4647-988b-dd90c7fcd232" />

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/f4d1703d-06f0-48b3-84ed-7ad0a66db569" />
