### PR TITLE
feat(ReportServiceCard): Add placeholder when OS is not detected [VUL-18]

### DIFF
--- a/src/modules/vulnerability/components/card/ReportServiceCard.vue
+++ b/src/modules/vulnerability/components/card/ReportServiceCard.vue
@@ -4,26 +4,35 @@
     <q-card flat class="bg-grey-2 q-pa-sm" style="border-radius: 1em">
       <q-card-section horizontal class="justify-between">
         <q-card-section class="col-6 flex column">
-          <div class="title">{{ assets.operating_system?.name || '' }}</div>
-          <div class="flex-1 flex column">
-            <div class="row q-pl-lg q-mt-sm">
-              <div class="col-3 text-weight-medium">
-                {{ $t('report.vulnerabilityCategory.version') }}
-              </div>
-              <div class="col">{{ assets.operating_system?.version }}</div>
+          <template v-if="assets.operating_system?.accuracy === 0 || !assets.operating_system">
+            <div class="text-h6 text-grey-7">Not Detected</div>
+            <div class="text-body2 text-grey-6 q-mt-sm">
+              The operating system could not be detected for this host
             </div>
-            <div class="row q-pl-lg flex-1 items-center">
-              <div class="col-3 text-weight-medium">
-                {{ $t('report.vulnerabilityCategory.precision') }}
+          </template>
+          <template v-else>
+            <div class="title">{{ assets.operating_system?.name || '' }}</div>
+            <div class="flex-1 flex column">
+              <div class="row q-pl-lg q-mt-sm">
+                <div class="col-3 text-weight-medium">
+                  {{ $t('report.vulnerabilityCategory.version') }}
+                </div>
+                <div class="col">{{ assets.operating_system?.version }}</div>
               </div>
-              <div class="col">{{ assets.operating_system?.accuracy }} %</div>
+              <div class="row q-pl-lg flex-1 items-center">
+                <div class="col-3 text-weight-medium">
+                  {{ $t('report.vulnerabilityCategory.precision') }}
+                </div>
+                <div class="col">{{ assets.operating_system?.accuracy }} %</div>
+              </div>
             </div>
-          </div>
+          </template>
         </q-card-section>
 
         <q-separator vertical />
         <q-card-section class="col-6 position-relative">
           <q-btn
+            v-if="assets.operating_system?.accuracy > 0 && assets.operating_system?.total_vulnerabilities_count > 0"
             square
             size="md"
             flat
@@ -33,21 +42,30 @@
             @click="goVulnerabilityOsTypeList()"
           ></q-btn>
           <div class="title">{{ $t('report.vulnerabilityCategory.details') }}</div>
-          <div class="row text-center full-width">
-            <div class="col-12 text-weight-bold text-body1">
-              {{ assets.operating_system?.total_vulnerabilities_count }}
-            </div>
-            <div class="col-12 text-body2">
-              {{ $t('report.vulnerabilityCategory.vulnerabilities') }}
-            </div>
-          </div>
-          <div class="row q-pa-none q-pt-md">
-            <template v-for="level in vulnerabilityLevels" :key="level">
-              <div class="vulnerability-count col" :class="level.toLocaleLowerCase()">
-                {{ assets.operating_system?.[level] }}
+          <template v-if="assets.operating_system?.accuracy === 0 || !assets.operating_system">
+            <div class="row text-center full-width q-mt-md">
+              <div class="col-12 text-body2 text-grey-6">
+                No vulnerability data available
               </div>
-            </template>
-          </div>
+            </div>
+          </template>
+          <template v-else>
+            <div class="row text-center full-width">
+              <div class="col-12 text-weight-bold text-body1">
+                {{ assets.operating_system?.total_vulnerabilities_count }}
+              </div>
+              <div class="col-12 text-body2">
+                {{ $t('report.vulnerabilityCategory.vulnerabilities') }}
+              </div>
+            </div>
+            <div class="row q-pa-none q-pt-md">
+              <template v-for="level in vulnerabilityLevels" :key="level">
+                <div class="vulnerability-count col" :class="level.toLocaleLowerCase()">
+                  {{ assets.operating_system?.[level] }}
+                </div>
+              </template>
+            </div>
+          </template>
         </q-card-section>
       </q-card-section>
     </q-card>
@@ -96,6 +114,7 @@
             <q-separator vertical />
             <q-card-section class="col-6 position-relative">
               <q-btn
+                v-if="service.total_vulnerabilities_count > 0"
                 square
                 size="md"
                 flat


### PR DESCRIPTION


## 🌟 What type of PR is this? (check all applicable)
- [ ] ♻️ Refactor
- [x] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🚀 Optimization
- [ ] 📚 Documentation Update

## 📝 Description

- Added a placeholder when an OS is not detected to improve UX. This happens when an OS is detected but the accuracy field === 0.
- Added logic to avoid rendering the asset vulnerabilities detail button when that asset's vulnerabilities are 0.

## 🔗 Related Tickets & Documents


- Related Issue # 
- Closes # [VUL-18](https://linear.app/kptm-audits/issue/VUL-18/ui-add-placeholder-when-operating-system-is-not-detected)

## 🧪 QA Instructions, Screenshots, Recordings

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/e155e4a4-9024-4873-9750-d0ae4a894eec" />
