### PR TITLE
chore: Deprecate the use of OTP [VUL-22]

### DIFF
--- a/src/constants/fusion-auth.constants.ts
+++ b/src/constants/fusion-auth.constants.ts
@@ -13,7 +13,6 @@ export const UNPROTECTED_PATHS = ['/api/login'];
 export enum AUTH_TOKEN_NAMES {
   ACCESS_TOKEN = 'access_token',
   TOKEN_EXPIRATION_INSTANT = 'token_expiration_instant',
-  OTP = 'otp',
   TENANT_ID = 'tenant_id',
   AUDITS = 'audits'
 }

--- a/src/modules/auth/helpers/__test__/sessionStorage.vitest.spec.ts
+++ b/src/modules/auth/helpers/__test__/sessionStorage.vitest.spec.ts
@@ -58,7 +58,6 @@ describe('Auth/helpers:sessionStorage', () => {
       const result = getSessionStorageValues();
       expect(result).toEqual({
         accessToken: 'partial_token',
-        otp: '',
         tokenExpirationInstant: 0,
         tenantId: '',
         audits: ''

--- a/src/modules/auth/helpers/__test__/sessionStorage.vitest.spec.ts
+++ b/src/modules/auth/helpers/__test__/sessionStorage.vitest.spec.ts
@@ -32,7 +32,6 @@ describe('Auth/helpers:sessionStorage', () => {
       const result = getSessionStorageValues();
       expect(result).toEqual({
         accessToken: '',
-        otp: '',
         tokenExpirationInstant: 0,
         tenantId: '',
         audits: ''
@@ -41,14 +40,12 @@ describe('Auth/helpers:sessionStorage', () => {
 
     it('should return stored values when all items are present', () => {
       sessionStorageMock[AUTH_TOKEN_NAMES.ACCESS_TOKEN] = 'test_access_token';
-      sessionStorageMock[AUTH_TOKEN_NAMES.OTP] = '123456';
       sessionStorageMock[AUTH_TOKEN_NAMES.TOKEN_EXPIRATION_INSTANT] = '1678886400000';
       sessionStorageMock[AUTH_TOKEN_NAMES.TENANT_ID] = 'test_tenant';
 
       const result = getSessionStorageValues();
       expect(result).toEqual({
         accessToken: 'test_access_token',
-        otp: '123456',
         tokenExpirationInstant: 1678886400000,
         tenantId: 'test_tenant',
         audits: ''
@@ -85,7 +82,6 @@ describe('Auth/helpers:sessionStorage', () => {
     it('should set all provided values into session storage and return them', () => {
       const dataToSet: sessionStorageKeys = {
         accessToken: 'new_access_token',
-        otp: '987654',
         tokenExpirationInstant: 1678900000000,
         tenantId: 'new_tenant',
         audits: ''
@@ -94,7 +90,6 @@ describe('Auth/helpers:sessionStorage', () => {
       const result = setSessionStorageValues(dataToSet);
 
       expect(sessionStorageMock[AUTH_TOKEN_NAMES.ACCESS_TOKEN]).toBe(dataToSet.accessToken);
-      expect(sessionStorageMock[AUTH_TOKEN_NAMES.OTP]).toBe(dataToSet.otp);
       expect(sessionStorageMock[AUTH_TOKEN_NAMES.TOKEN_EXPIRATION_INSTANT]).toBe(
         dataToSet.tokenExpirationInstant.toString()
       );
@@ -105,7 +100,6 @@ describe('Auth/helpers:sessionStorage', () => {
     it('should handle empty string inputs for string fields', () => {
       const dataToSet: sessionStorageKeys = {
         accessToken: '',
-        otp: '',
         tokenExpirationInstant: 12345,
         tenantId: '',
         audits: ''
@@ -113,14 +107,12 @@ describe('Auth/helpers:sessionStorage', () => {
 
       setSessionStorageValues(dataToSet);
       expect(sessionStorageMock[AUTH_TOKEN_NAMES.ACCESS_TOKEN]).toBe('');
-      expect(sessionStorageMock[AUTH_TOKEN_NAMES.OTP]).toBe('');
       expect(sessionStorageMock[AUTH_TOKEN_NAMES.TENANT_ID]).toBe('');
     });
 
     it('should handle zero for tokenExpirationInstant', () => {
       const dataToSet: sessionStorageKeys = {
         accessToken: 'some_token',
-        otp: '123',
         tokenExpirationInstant: 0,
         tenantId: 'some_tenant',
         audits: ''
@@ -136,24 +128,20 @@ describe('Auth/helpers:sessionStorage', () => {
   describe('clearSessionStorageValues', () => {
     it('should remove all authentication-related items from session storage', () => {
       sessionStorageMock[AUTH_TOKEN_NAMES.ACCESS_TOKEN] = 'token_to_clear';
-      sessionStorageMock[AUTH_TOKEN_NAMES.OTP] = 'otp_to_clear';
       sessionStorageMock[AUTH_TOKEN_NAMES.TOKEN_EXPIRATION_INSTANT] = '123';
       sessionStorageMock[AUTH_TOKEN_NAMES.TENANT_ID] = 'tenant_to_clear';
 
       expect(sessionStorageMock).toHaveProperty(AUTH_TOKEN_NAMES.ACCESS_TOKEN);
-      expect(sessionStorageMock).toHaveProperty(AUTH_TOKEN_NAMES.OTP);
 
       clearSessionStorageValues();
 
       expect(sessionStorageMock).not.toHaveProperty(AUTH_TOKEN_NAMES.ACCESS_TOKEN);
-      expect(sessionStorageMock).not.toHaveProperty(AUTH_TOKEN_NAMES.OTP);
       expect(sessionStorageMock).not.toHaveProperty(AUTH_TOKEN_NAMES.TOKEN_EXPIRATION_INSTANT);
       expect(sessionStorageMock).not.toHaveProperty(AUTH_TOKEN_NAMES.TENANT_ID);
 
       const result = getSessionStorageValues();
       expect(result).toEqual({
         accessToken: '',
-        otp: '',
         tokenExpirationInstant: 0,
         tenantId: '',
         audits: ''
@@ -165,7 +153,6 @@ describe('Auth/helpers:sessionStorage', () => {
       const result = getSessionStorageValues();
       expect(result).toEqual({
         accessToken: '',
-        otp: '',
         tokenExpirationInstant: 0,
         tenantId: '',
         audits: ''

--- a/src/modules/auth/helpers/sessionStorage.ts
+++ b/src/modules/auth/helpers/sessionStorage.ts
@@ -5,16 +5,15 @@ import type { sessionStorageKeys } from 'auth/models/sessionStorage';
  * @function getSessionStorageValues
  * @description
  * Retrieves authentication-related values from the browser's `sessionStorage`.
- * It attempts to fetch the access token, one-time password (OTP), token expiration
- * instant, and tenant ID. If any value is not found in session storage, it defaults
- * to an empty string for string values or `0` for the token expiration instant.
+ * It attempts to fetch the access token, token expiration instant, and tenant ID.
+ * If any value is not found in session storage, it defaults to an empty string
+ * for string values or `0` for the token expiration instant.
  *
  * @returns {SessionStorageKeys} An object containing the retrieved session storage values.
  */
 export function getSessionStorageValues(): sessionStorageKeys {
   return {
     accessToken: sessionStorage.getItem(AUTH_TOKEN_NAMES.ACCESS_TOKEN) || '',
-    otp: sessionStorage.getItem(AUTH_TOKEN_NAMES.OTP) || '',
     tokenExpirationInstant:
       Number(sessionStorage.getItem(AUTH_TOKEN_NAMES.TOKEN_EXPIRATION_INSTANT)) || 0,
     tenantId: sessionStorage.getItem(AUTH_TOKEN_NAMES.TENANT_ID) || '',
@@ -26,14 +25,13 @@ export function getSessionStorageValues(): sessionStorageKeys {
  * @function clearSessionStorageValues
  * @description
  * Clears all stored authentication values from `sessionStorage`.
- * This effectively removes the access token, OTP, token expiration instant,
+ * This effectively removes the access token, token expiration instant,
  * and tenant ID, ensuring no residual authentication data.
  *
  * @returns {void}
  */
 export function clearSessionStorageValues(): void {
   sessionStorage.removeItem(AUTH_TOKEN_NAMES.ACCESS_TOKEN);
-  sessionStorage.removeItem(AUTH_TOKEN_NAMES.OTP);
   sessionStorage.removeItem(AUTH_TOKEN_NAMES.TOKEN_EXPIRATION_INSTANT);
   sessionStorage.removeItem(AUTH_TOKEN_NAMES.TENANT_ID);
   sessionStorage.removeItem(AUTH_TOKEN_NAMES.AUDITS);
@@ -43,7 +41,7 @@ export function clearSessionStorageValues(): void {
  * @function setSessionStorageValues
  * @description
  * Stores authentication-related values into `sessionStorage`. This includes
- * the access token, token expiration instant, OTP, and tenant ID.
+ * the access token, token expiration instant, and tenant ID.
  * The `tokenExpirationInstant` is converted to a string before storage.
  * After setting the values, it immediately retrieves and returns them from
  * session storage to confirm successful storage.
@@ -51,7 +49,6 @@ export function clearSessionStorageValues(): void {
  * @param {sessionStorageKeys} data - An object containing the authentication
  * data to be stored.
  * - `accessToken`: The JWT access token.
- * - `otp`: The one-time password.
  * - `tokenExpirationInstant`: The timestamp when the token expires (number).
  * - `tenantId`: The identifier for the tenant.
  *
@@ -64,7 +61,6 @@ export function setSessionStorageValues(data: sessionStorageKeys): sessionStorag
     AUTH_TOKEN_NAMES.TOKEN_EXPIRATION_INSTANT,
     data.tokenExpirationInstant.toString()
   );
-  sessionStorage.setItem(AUTH_TOKEN_NAMES.OTP, data.otp);
   sessionStorage.setItem(AUTH_TOKEN_NAMES.TENANT_ID, data.tenantId);
   sessionStorage.setItem(AUTH_TOKEN_NAMES.AUDITS, data.audits);
 

--- a/src/modules/auth/models/fusion-auth.models.ts
+++ b/src/modules/auth/models/fusion-auth.models.ts
@@ -64,7 +64,6 @@ export interface SuccessAuthLogin {
   token: string;
   tokenExpirationInstant: number;
   user: SuccessAuthLoginUser;
-  otp: string;
   tenantId: string;
   audits: string;
 }

--- a/src/modules/auth/models/sessionStorage.ts
+++ b/src/modules/auth/models/sessionStorage.ts
@@ -1,6 +1,5 @@
 export interface sessionStorageKeys {
   accessToken: string;
-  otp: string;
   tokenExpirationInstant: number;
   tenantId: string;
   audits: string;

--- a/src/modules/auth/stores/__tests__/fusion-auth.vitest.test.ts
+++ b/src/modules/auth/stores/__tests__/fusion-auth.vitest.test.ts
@@ -23,15 +23,13 @@ describe('FusionAuth API Service', () => {
       const body: FusionAuthLoginBody = {
         applicationId: 'appId',
         loginId: 'testuser',
-        password: 'testpassword',
-        otp: 'otp'
+        password: 'testpassword'
       };
       const mockResponse: AxiosResponse<FusionAuthLoginResponse> = {
         data: {
           token: 'mockToken',
           tokenExpirationInstant: 1,
           user: {} as SuccessAuthLoginUser,
-          otp: 'otp',
           tenantId: '',
           audits: ''
         },
@@ -56,8 +54,7 @@ describe('FusionAuth API Service', () => {
       const body: FusionAuthLoginBody = {
         applicationId: 'appId',
         loginId: 'testuser',
-        password: 'wrongpassword',
-        otp: 'otp'
+        password: 'wrongpassword'
       };
       const mockError = new Error('Login failed');
       (fusionAuthApi.post as ReturnType<typeof vi.fn>).mockRejectedValue(mockError);

--- a/src/modules/auth/stores/auth-store.ts
+++ b/src/modules/auth/stores/auth-store.ts
@@ -48,7 +48,6 @@ export const useAuthStore = defineStore('auth-store', {
           const updatedResponse: SuccessAuthLogin = response.data as SuccessAuthLogin;
           const sessionStorage: sessionStorageKeys = {
             accessToken: updatedResponse.token,
-            otp: updatedResponse.otp,
             tenantId: updatedResponse.tenantId,
             tokenExpirationInstant: updatedResponse.tokenExpirationInstant,
             audits: updatedResponse.audits

--- a/src/modules/shared/helpers/router.ts
+++ b/src/modules/shared/helpers/router.ts
@@ -23,10 +23,10 @@ export async function handlerRouterAuth(
   next: NavigationGuardNext
 ): Promise<void> {
   const authStore = useAuthStore();
-  const { accessToken, otp, tokenExpirationInstant, tenantId, audits } = getSessionStorageValues();
+  const { accessToken, tokenExpirationInstant, tenantId, audits } = getSessionStorageValues();
 
   //Save session storage information in store
-  authStore.setTokenInfo({ accessToken, tokenExpirationInstant, otp, tenantId, audits });
+  authStore.setTokenInfo({ accessToken, tokenExpirationInstant, tenantId, audits });
 
   if (!routeRequiresAuth(to)) {
     next();
@@ -54,7 +54,6 @@ export async function handlerRouterAuth(
       {
         accessToken,
         tokenExpirationInstant,
-        otp,
         tenantId,
         audits
       },

--- a/src/modules/vulnerability/pages/ReportPage.vue
+++ b/src/modules/vulnerability/pages/ReportPage.vue
@@ -333,14 +333,13 @@
   );
 
   onMounted(async () => {
-    const otp = sessionStorage.getItem(AUTH_TOKEN_NAMES.OTP);
     const tenantId = sessionStorage.getItem(AUTH_TOKEN_NAMES.TENANT_ID);
     isMounted.value = true;
 
     await fillReportData();
 
     wssConnection.value = new WebSocketReports(
-      `${process.env.BE_SERVER_WSS}/ws/report/?tenantId=${tenantId}&otp=${otp}`
+      `${process.env.BE_SERVER_WSS}/ws/report/?tenantId=${tenantId}`
     );
 
     wssConnection.value.connect();

--- a/src/modules/vulnerability/pages/ScanPage.vue
+++ b/src/modules/vulnerability/pages/ScanPage.vue
@@ -65,10 +65,9 @@
   }
 
   onMounted(() => {
-    const otp = sessionStorage.getItem(AUTH_TOKEN_NAMES.OTP);
     const tenantId = sessionStorage.getItem(AUTH_TOKEN_NAMES.TENANT_ID);
     connection.value = new WebSocket(
-      `${process.env.BE_SERVER_WSS}/ws/scan?tenantId=${tenantId}&otp=${otp}`
+      `${process.env.BE_SERVER_WSS}/ws/scan?tenantId=${tenantId}`
     );
     connection.value.onmessage = (data: { data: string }) => {
       scans.value = JSON.parse(data.data);


### PR DESCRIPTION
## 🌟 What type of PR is this? (check all applicable)
- [x] ♻️ Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🚀 Optimization
- [ ] 📚 Documentation Update

## 📝 Description

This PR removes the use of OTP as an authorization mechanism at the web-ui level. This change was made as a requirement before the migration of the vulnerabilities module over to the API Gateway, which does not handle OTPs for websockets. 

## 🔗 Related Tickets & Documents

- Related Issue #
- Closes # [VUL-22](https://linear.app/dev-team-d/issue/VUL-22/deprecate-the-use-of-otp)

## 🧪 QA Instructions, Screenshots, Recordings

Websockets still working without OTP!
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/ea075534-d9a2-47fa-b37d-7b3c5c662874" />



## ✅ Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [x] 👍 Yes
- [ ] 🚫 No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] 🙋‍♀️ I need help with writing tests
