### PR TITLE
feat: Frontend Runtime Configuration Implementation [AUD-197]

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,13 @@
-FUSION_SERVER_URL=http://localhost:8000
-GATEWAY_URL=http://localhost:8000
+# Development environment variables (used for local development)
+# For production/Docker deployments, these are overridden by runtime config
+
+# API endpoint for backend services
+AUDITS_SERVER_URL=http://localhost:8000
+
+# WebSocket endpoint for real-time features
 BE_SERVER_WSS=ws://localhost:8000/api/core
+
+# Note: When running in Docker/Kubernetes, these values are replaced
+# by runtime configuration via environment variables:
+# - API_BASE_URL (e.g., http://api.kptm.local)
+# - WS_BASE_URL (e.g., ws://api.kptm.local/api/core)

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,12 +34,37 @@ RUN npm run build
 
 FROM nginx:stable-alpine AS prod
 
+# Install envsubst for runtime variable substitution
+RUN apk add --no-cache gettext
+
+# Remove default nginx config
 RUN rm /etc/nginx/conf.d/default.conf
 
 # Copy the built SPA from the 'build' stage
 COPY --from=build /app/dist/spa /usr/share/nginx/html
 
+# Copy config template
+COPY --from=build /app/public/config.js.template /usr/share/nginx/html/config.js.template
+
+# Copy nginx configuration
+COPY nginx/default.conf /etc/nginx/conf.d/default.conf
+
+# Create entrypoint script for runtime configuration
+RUN echo '#!/bin/sh' > /docker-entrypoint.sh && \
+    echo 'set -e' >> /docker-entrypoint.sh && \
+    echo '' >> /docker-entrypoint.sh && \
+    echo '# Set default values if not provided' >> /docker-entrypoint.sh && \
+    echo ': ${API_BASE_URL:="http://localhost:8000"}' >> /docker-entrypoint.sh && \
+    echo ': ${WS_BASE_URL:="ws://localhost:8000/api/core"}' >> /docker-entrypoint.sh && \
+    echo '' >> /docker-entrypoint.sh && \
+    echo '# Generate runtime config from template' >> /docker-entrypoint.sh && \
+    echo 'envsubst < /usr/share/nginx/html/config.js.template > /usr/share/nginx/html/config.js' >> /docker-entrypoint.sh && \
+    echo '' >> /docker-entrypoint.sh && \
+    echo '# Start nginx' >> /docker-entrypoint.sh && \
+    echo 'exec nginx -g "daemon off;"' >> /docker-entrypoint.sh && \
+    chmod +x /docker-entrypoint.sh
+
 EXPOSE 80
 
-# Start nginx to serve the application
-CMD ["nginx", "-g", "daemon off;"]
+# Use the entrypoint script
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@
 
     <link href="favicon.svg" rel="icon" type="image/ico" />
     <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="/config.js"></script>
   </head>
   <body>
     <!-- quasar:entry-point -->

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,17 +1,37 @@
 server {
- listen 80;
- server_name kptmpentest.devteamdelta.org;
-location / {
- root /usr/share/nginx/html;
- index index.html index.htm;
- try_files $uri $uri/ /index.html;
- }
- location /api/ {
-   proxy_pass http://core-service:8000/;
-   proxy_set_header Host $host;
-   proxy_set_header X-Real-IP $remote_addr;
-   proxy_set_header X-Forwarder-For $proxy_add_x_forwarded_for;
-   proxy_set_header X-Forwarded-Proto $scheme;
- }
- proxy_set_header Content-Security-Policy upgrade-insecure-requests;
+    listen 80;
+    server_name _;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # Enable gzip compression
+    gzip on;
+    gzip_vary on;
+    gzip_min_length 1024;
+    gzip_types text/plain text/css text/xml text/javascript application/javascript application/xml+rss application/json;
+
+    # Security headers
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-XSS-Protection "1; mode=block" always;
+
+    # Serve config.js with proper cache headers
+    location = /config.js {
+        root /usr/share/nginx/html;
+        add_header Cache-Control "no-cache, no-store, must-revalidate";
+        add_header Pragma "no-cache";
+        add_header Expires "0";
+    }
+
+    # Handle client-side routing (SPA)
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    # Health check endpoint
+    location /healthz {
+        access_log off;
+        return 200 "healthy\n";
+        add_header Content-Type text/plain;
+    }
 }

--- a/public/config.js.template
+++ b/public/config.js.template
@@ -1,0 +1,6 @@
+// Runtime configuration for the application
+// This file is processed at container startup to inject environment variables
+window.APP_CONFIG = {
+  API_BASE_URL: '${API_BASE_URL}',
+  WS_BASE_URL: '${WS_BASE_URL}'
+};

--- a/src/boot/axios.ts
+++ b/src/boot/axios.ts
@@ -17,8 +17,16 @@ const isUnprotected = (url: string): boolean => {
   return UNPROTECTED_PATHS.some(endpoint => url.includes(endpoint));
 };
 
+// Use runtime config if available, fallback to build-time env or localhost
+const getApiBaseUrl = (): string => {
+  if (typeof window !== 'undefined' && window.APP_CONFIG?.API_BASE_URL) {
+    return window.APP_CONFIG.API_BASE_URL;
+  }
+  return process.env.AUDITS_SERVER_URL || 'http://localhost:8000';
+};
+
 const gatewayApi = axios.create({
-  baseURL: process.env.AUDITS_SERVER_URL || 'http://localhost:8000'
+  baseURL: getApiBaseUrl()
 });
 
 gatewayApi.interceptors.request.use(

--- a/src/modules/vulnerability/pages/ReportPage.vue
+++ b/src/modules/vulnerability/pages/ReportPage.vue
@@ -338,8 +338,9 @@
 
     await fillReportData();
 
+    const wsUrl = window.APP_CONFIG?.WS_BASE_URL || process.env.BE_SERVER_WSS || 'ws://localhost:8000/api/core';
     wssConnection.value = new WebSocketReports(
-      `${process.env.BE_SERVER_WSS}/ws/report/?tenantId=${authStore.tenantId}`
+      `${wsUrl}/ws/report/?tenantId=${authStore.tenantId}`
     );
 
     wssConnection.value.connect();

--- a/src/modules/vulnerability/pages/ScanPage.vue
+++ b/src/modules/vulnerability/pages/ScanPage.vue
@@ -66,8 +66,9 @@
   }
 
   onMounted(() => {
+    const wsUrl = window.APP_CONFIG?.WS_BASE_URL || process.env.BE_SERVER_WSS || 'ws://localhost:8000/api/core';
     connection.value = new WebSocket(
-      `${process.env.BE_SERVER_WSS}/ws/scan?tenantId=${authStore.tenantId}`
+      `${wsUrl}/ws/scan?tenantId=${authStore.tenantId}`
     );
     connection.value.onmessage = (data: { data: string }) => {
       scans.value = JSON.parse(data.data);

--- a/src/types/window.d.ts
+++ b/src/types/window.d.ts
@@ -1,0 +1,13 @@
+// Type declarations for runtime configuration
+interface AppConfig {
+  API_BASE_URL: string;
+  WS_BASE_URL: string;
+}
+
+declare global {
+  interface Window {
+    APP_CONFIG?: AppConfig;
+  }
+}
+
+export {};


### PR DESCRIPTION
## 🌟 What type of PR is this? (check all applicable)
- [x] ♻️ Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 🚀 Optimization
- [ ] 📚 Documentation Update

## 📝 Description

Implemented runtime configuration for the `web-ui` application, replacing build-time environment variables with a cloud-native runtime configuration pattern. This enables the same Docker image to work across all environments (dev, staging, production) without rebuilding.

### 🎯 Problem Solved  

Previously the frontend was using `process.env.AUDITS_SERVER_URL` which was _baked_ into the JavaScript bundle at build time, defaulting to `http://localhost:8000`. This meant:

- ❌ Different images needed for different environments
- ❌ API URLs were hardcoded in the built Javascript
- ❌ Kubernetes environment variables had no effect on the already-built static files
- ❌ CORS issues when frontend tried to reach wrong endpoints

### 🧑‍🦱 Developer Impact

#### Local Development (No Changes ✅ )

```bash
# Still works the same
npm run dev
# uses .env file: AUDITS_SERVER_URL=http://localhost:8000
```

#### Docker Development 🐳 

```bash
# Build once, configure at runtime
docker build -t web-ui:latest .
docker run -e API_BASE_URL=http://api.example.com web-ui:latest
```

Then test with env vars at runtime

```bash
docker run -p \
  -e API_BASE_URL="https://api.production.com" \
  -e WS_BASE_URL="wss://api.production.com/ws" \
web-ui:latest
```

### ♻️  Migration Notes

- `AUDITS_SERVER_URL` -> `API_BASE_URL`
- `BE_SERVER_WSS` -> `WS_BASE_URL`

## 🔗 Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Closes [AUD-197](https://linear.app/dev-team-d/issue/AUD-197/frontend-runtime-configuration-implementation)

## 🧪 QA Instructions, Screenshots, Recordings

```
# After deploying, you can verify the config by doing
curl http://your-app/config.js
```

Which should return something like:

```js
window.APP_CONFIG = { 
  API_BASE_URL: 'http://api.kptm.local',
  WS_BASE_URL: 'ws://api.kptm.local/api/core'
};
