### PR TITLE
fix: Update misleading and incorrect host creation labels [VUL-33]

### DIFF
--- a/src/modules/vulnerability/components/dialog/DialogHostUnified.vue
+++ b/src/modules/vulnerability/components/dialog/DialogHostUnified.vue
@@ -25,7 +25,7 @@
               <q-input
                 v-model="hostData.value"
                 outlined
-                label="Target URL or IP *"
+                label="Target FQDN or IP *"
                 hint="Enter a domain (e.g., example.com) or IP address (e.g., 192.168.1.1)"
                 :rules="[val => !!val || 'Target is required']"
                 class="q-mb-md"

--- a/src/modules/vulnerability/models/hosts.ts
+++ b/src/modules/vulnerability/models/hosts.ts
@@ -17,6 +17,7 @@ export interface Host {
   value_type?: 'Domain' | 'Subdomain' | 'IP';
   created_at?: string;
   creationDate?: string;
+  originalCreationDate?: string;
   hostName?: string;
   ip?: string;
   alias?: string;

--- a/src/modules/vulnerability/stores/host.ts
+++ b/src/modules/vulnerability/stores/host.ts
@@ -41,7 +41,12 @@ export const useHostStore = defineStore('host', {
           }
 
           if (key === 'created_at') {
-            return host.creationDate?.slice(0, 10) === filterValue.slice(0, 10);
+            interface HostWithOriginalDate extends Host {
+              originalCreationDate?: string;
+            }
+            const originalDate = (host as HostWithOriginalDate).originalCreationDate || host.created_at;
+            if (!originalDate) return false;
+            return originalDate.slice(0, 10) === filterValue.slice(0, 10);
           }
 
           return host[key as keyof Host] === filterValue;

--- a/src/modules/vulnerability/stores/host.ts
+++ b/src/modules/vulnerability/stores/host.ts
@@ -41,10 +41,7 @@ export const useHostStore = defineStore('host', {
           }
 
           if (key === 'created_at') {
-            interface HostWithOriginalDate extends Host {
-              originalCreationDate?: string;
-            }
-            const originalDate = (host as HostWithOriginalDate).originalCreationDate || host.created_at;
+            const originalDate = host.originalCreationDate || host.created_at;
             if (!originalDate) return false;
             return originalDate.slice(0, 10) === filterValue.slice(0, 10);
           }

--- a/src/utils/__test__/host.utils.vitest.spec.ts
+++ b/src/utils/__test__/host.utils.vitest.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { formatHostForTable, getPrincipalRapporteur } from '../host.utils';
 import type { Host, Rapporteur } from 'vulnerability/models/hosts';
+import { formatHostDate } from '../date.utils';
 
 // Mock the HostService
 vi.mock('src/services/host.service', () => ({
@@ -63,7 +64,8 @@ describe('host.utils', () => {
           ],
           credentials: [],
           hostName: 'Server A',
-          creationDate: '2023-01-15T10:00:00Z',
+          creationDate: formatHostDate('2023-01-15T10:00:00Z'),
+          originalCreationDate: '2023-01-15T10:00:00Z',
           email: 'primary@example.com'
         },
         {
@@ -73,7 +75,8 @@ describe('host.utils', () => {
           rapporteurs: [{ email: 'single@test.com', is_principal: true, name: 'test' }],
           credentials: [],
           hostName: 'Database B',
-          creationDate: '2023-02-20T14:30:00Z',
+          creationDate: formatHostDate('2023-02-20T14:30:00Z'),
+          originalCreationDate: '2023-02-20T14:30:00Z',
           email: 'single@test.com'
         },
         {
@@ -83,7 +86,8 @@ describe('host.utils', () => {
           rapporteurs: [],
           credentials: [],
           hostName: 'API Gateway C',
-          creationDate: '2023-03-01T08:00:00Z',
+          creationDate: formatHostDate('2023-03-01T08:00:00Z'),
+          originalCreationDate: '2023-03-01T08:00:00Z',
           email: ''
         }
       ];

--- a/src/utils/date.utils.ts
+++ b/src/utils/date.utils.ts
@@ -4,6 +4,25 @@ export function formatTableDate(date: string): string {
   return formattedDate;
 }
 
+export function formatHostDate(dateString: string | undefined): string {
+  if (!dateString) return '';
+
+  const date = new Date(dateString);
+  if (isNaN(date.getTime())) return '';
+
+  const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+  const month = months[date.getMonth()];
+  const day = date.getDate();
+  const year = date.getFullYear();
+
+  let hours = date.getHours();
+  const minutes = date.getMinutes().toString().padStart(2, '0');
+  const ampm = hours >= 12 ? 'PM' : 'AM';
+  hours = hours % 12 || 12;
+
+  return `${month} ${day}, ${year} ${hours}:${minutes} ${ampm}`;
+}
+
 export function formatDateTimeToServer(
   dateFormat: string | null = '',
   timeFormat: string | null = ''

--- a/src/utils/host.utils.ts
+++ b/src/utils/host.utils.ts
@@ -1,12 +1,14 @@
 import type { Host, Rapporteur } from 'vulnerability/models/hosts';
 import { HostService } from 'vulnerability/services/host';
 import { useHostStore } from 'vulnerability/stores/host';
+import { formatHostDate } from './date.utils';
 
 export function formatHostForTable(hosts: Host[]): Host[] {
   return hosts.map(host => ({
     ...host,
     hostName: host.name,
-    creationDate: host.created_at,
+    creationDate: formatHostDate(host.created_at),
+    originalCreationDate: host.created_at,
     email: getPrincipalRapporteur(host.rapporteurs)
   })) as Host[];
 }


### PR DESCRIPTION
This PR fixes two observations from the Kriptome team:

1. The label for "Target URL" was misleading, since what we're actually asking for is the target's FDQN
2. The column "Creation Date" was incorrectly formatting ISO strings for dates.

## 🌟 What type of PR is this? (check all applicable)
- [ ] ♻️ Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 🚀 Optimization
- [ ] 📚 Documentation Update

## 📝 Description

## 🔗 Related Tickets & Documents

- Closes [VUL-33](https://linear.app/dev-team-d/issue/VUL-33/cambiar-o-agregar-tagtarget-url-por-fqdn)

## 🧪 QA Instructions, Screenshots, Recordings

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/02a25ca1-8d12-49ef-b13b-ba40e20f2f6d" />

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/2413484f-220e-4ffe-8ec5-292f548f105b" />


## ✅ Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [x] 👍 Yes
- [ ] 🚫 No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] 🙋‍♀️ I need help with writing tests
