### PR TITLE
fix: Report page action handler names

### DIFF
--- a/src/modules/vulnerability/pages/ReportPage.vue
+++ b/src/modules/vulnerability/pages/ReportPage.vue
@@ -259,12 +259,12 @@
             caption: err?.message || String(err)
           });
         });
-    } else if (action.action === 'search') {
+    } else if (action.action === 'view_assets') {
       await router.push({
         name: VULNERABILITY_ROUTES.reportsVulnerabilities.name,
         params: { id: action.col.scan_id }
       });
-    } else if (action.action === 'detail') {
+    } else if (action.action === 'polar_report') {
       wssConnection.value?.send({
         type: WebSocketMessageRequest.INITIAL_DATA_REQUEST,
         payload: {


### PR DESCRIPTION


## 🌟 What type of PR is this? (check all applicable)
- [ ] ♻️ Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 🚀 Optimization
- [ ] 📚 Documentation Update

## 📝 Description

Recently the "Polar Graph" and "Scan Assets" actions were renamed, but the report handler did not cover these changes. This PR addresses this fix. 

## 🔗 Related Tickets & Documents

<img width="1904" height="978" alt="image" src="https://github.com/user-attachments/assets/27358930-1b20-4644-a568-1d5a5d2a4e6f" />

- Related Issue #
- Closes #

## 🧪 QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, a note
on the devices and browsers this has been tested on, as well as any relevant
images for UI changes._

## ✅ Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [ ] 👍 Yes
- [ ] 🚫 No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] 🙋‍♀️ I need help with writing tests
