### PR TITLE
fix: IP-Type Host Names are not displayed [VUL-36]

### DIFF
--- a/src/constants/table.constants.ts
+++ b/src/constants/table.constants.ts
@@ -11,6 +11,12 @@ export const TABLE_ACTIONS_COLUMN: QTableColumn = {
 export const HOST_TABLE_ACTIONS: tableActions[] = [TableActions.EDIT, TableActions.DELETE];
 export const HOST_TABLE_COLUMNS: QTableColumn[] = [
   {
+    name: 'Host Name',
+    label: 'HostName',
+    align: 'left',
+    field: 'hostName'
+  },
+  {
     name: 'Domain',
     label: 'Domain',
     align: 'left',
@@ -21,12 +27,6 @@ export const HOST_TABLE_COLUMNS: QTableColumn[] = [
     label: 'Ip',
     align: 'left',
     field: 'ip'
-  },
-  {
-    name: 'Host Name',
-    label: 'HostName',
-    align: 'left',
-    field: 'hostName'
   },
   {
     name: 'Creation Date',

--- a/src/modules/vulnerability/components/card/PickHostsCard.vue
+++ b/src/modules/vulnerability/components/card/PickHostsCard.vue
@@ -29,7 +29,7 @@
             :options="hosts"
             use-chips
             stack-label
-            option-label="domain"
+            option-label="name"
           />
         </div>
       </div>
@@ -71,6 +71,13 @@
       align: 'left',
       label: 'Domain',
       field: 'domain',
+      sortable: true
+    },
+    {
+      name: 'ip',
+      align: 'left',
+      label: 'IP',
+      field: 'ip',
       sortable: true
     }
   ];


### PR DESCRIPTION
<!--
     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## 🌟 What type of PR is this? (check all applicable)
- [ ] ♻️ Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 🚀 Optimization
- [ ] 📚 Documentation Update

## 📝 Description

This PR fixes a bug where creating a host with just an IP value led to confusing empty values being shown in selection dropdowns for scans.

- Hosts table columns were re-ordered to prioritize Host Name (alias)
- The scan select host dropdown card was updated to show HostNames instead of domains
- The 2nd step of the scan select card was updated to show HostNames, domains and IPs instead of just HostNames and IPS

## 🔗 Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Closes [VUL-36](https://linear.app/dev-team-d/issue/VUL-36/ip-type-host-names-are-not-displayed)

## 🧪 QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, a note
on the devices and browsers this has been tested on, as well as any relevant
images for UI changes._

### Host Details Table Re-Ordering

Before
<img width="1904" height="978" alt="image" src="https://github.com/user-attachments/assets/3014f1c5-edd3-4c39-98f0-686d866f51c2" />

After
<img width="1466" height="981" alt="image" src="https://github.com/user-attachments/assets/acb9dc48-6a0b-4cf8-9a09-3aa8268ecb08" />


### Scan Host Pick Dropdown
Before (Host with only IP value not showing)
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/eb43a9ae-3842-4a99-a9c0-7bbd8764c8df" />

After
<img width="1466" height="981" alt="image" src="https://github.com/user-attachments/assets/341b1a7c-0df8-41d5-a723-cb7ae7b51201" />

### Step 2 now shows IP values as well
<img width="1466" height="981" alt="image" src="https://github.com/user-attachments/assets/41303055-a629-4ea3-a1bb-50d408d8894d" />


## ✅ Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [ ] 👍 Yes
- [x] 🚫 No, and this is why: These changes were mostly UI/UX, and writing tests would have been brittle and not logic related.
- [ ] 🙋‍♀️ I need help with writing tests
